### PR TITLE
Upgrade GA CPU CI

### DIFF
--- a/.github/workflows/ci-cpu.yaml
+++ b/.github/workflows/ci-cpu.yaml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout Action
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Instantiate
         run: julia --project -e 'using Pkg; Pkg.instantiate();'
@@ -27,7 +27,7 @@ jobs:
         run: julia -t 4 --project -e 'using Pkg; Pkg.test()'
 
   macos:
-    runs-on: macos-latest
+    runs-on: macos-13
     strategy:
       fail-fast: false
       matrix:
@@ -35,10 +35,16 @@ jobs:
 
     steps:
       - name: Checkout Action
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Install julia
+        run: |
+          brew update
+          brew install julia
+          julia --version
 
       - name: Instantiate
         run: julia --project -e 'using Pkg; Pkg.instantiate();'
 
       - name: Test Threads
-        run: julia -t 3 --project -e 'using Pkg; Pkg.test()'
+        run: julia -t 4 --project -e 'using Pkg; Pkg.test()'


### PR DESCRIPTION
Bump checkout action to v4
Bump to macos-13 runners with 4 cores