### PR TITLE
CI: Update Instantiate to load rocm, just like Test.

### DIFF
--- a/.github/workflows/ci-gpu-AMD.yaml
+++ b/.github/workflows/ci-gpu-AMD.yaml
@@ -76,7 +76,7 @@ jobs:
         run: |
           source /etc/profile.d/lmod.sh
           module load julia/1.9.1
-          module load rocm/6.0.0
+          module load rocm
           julia --project -e 'using Pkg; Pkg.instantiate()'
           julia --project -e 'using Pkg; Pkg.add(name="AMDGPU", version="v0.8.6")'
           julia --project -e 'using AMDGPU; AMDGPU.use_artifacts!(false)'


### PR DESCRIPTION
Load generic `rocm` instead of `rocm/6.0.0`.