### PR TITLE
Add suport for Atomix.@atomic across back ends

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["pedrovalerolara <valerolarap@ornl.gov>", "williamfgc <williamfgc@yah
 version = "0.0.3"
 
 [deps]
+Atomix = "a9b6321e-bd34-4604-b9c9-b65b8de01458"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 
 [weakdeps]

--- a/src/JACC.jl
+++ b/src/JACC.jl
@@ -1,11 +1,12 @@
 __precompile__(false)
 module JACC
 
+import Atomix: @atomic
 # module to set back end preferences 
 include("JACCPreferences.jl")
 include("helper.jl")
 
-export Array
+export Array, @atomic
 export parallel_for
 
 global Array

--- a/test/tests_amdgpu.jl
+++ b/test/tests_amdgpu.jl
@@ -52,3 +52,23 @@ end
 
 	@test Array(x_device) ≈ x_expected rtol = 1e-1
 end
+
+@testset "AtomicCounter" begin
+
+	function axpy_counter!(i, alpha, x, y, counter)
+		@inbounds x[i] += alpha * y[i]
+		JACC.@atomic counter[1] += 1
+	end
+
+	N = Int32(10)
+	# Generate random vectors x and y of length N for the interval [0, 100]
+	alpha = 2.5
+
+	x = JACC.Array(round.(rand(Float32, N) * 100))
+	y = JACC.Array(round.(rand(Float32, N) * 100))
+	counter = JACC.Array{Int32}([0])
+	JACC.parallel_for(N, axpy_counter!, alpha, x, y, counter)
+
+	@test Array(counter)[1] == N
+end
+

--- a/test/tests_cuda.jl
+++ b/test/tests_cuda.jl
@@ -53,6 +53,26 @@ end
 	@test Array(x_device) ≈ x_expected rtol = 1e-1
 end
 
+@testset "AtomicCounter" begin
+
+	function axpy_counter!(i, alpha, x, y, counter)
+		@inbounds x[i] += alpha * y[i]
+		JACC.@atomic counter[1] += 1
+	end
+
+	N = Int32(10)
+	# Generate random vectors x and y of length N for the interval [0, 100]
+	alpha = 2.5
+
+	x = JACC.Array(round.(rand(Float32, N) * 100))
+	y = JACC.Array(round.(rand(Float32, N) * 100))
+	counter = JACC.Array{Int32}([0])
+	JACC.parallel_for(N, axpy_counter!, alpha, x, y, counter)
+
+	@test Array(counter)[1] == N
+end
+
+
 
 
 


### PR DESCRIPTION
Atomix is supported by Threads, CUDA and [AMDGPU](https://github.com/JuliaGPU/AMDGPU.jl/issues/547) back ends.
TBD for oneAPI.jl

import `Atomix.@atomic` into the JACC module namespace, so `JACC.@atomix` can be used without the need to import Atomix from consumers.
Added unit tests for AtomicCounter
Can only be used on arrays, not single value variables
Fixes #55 