### PR TITLE
Avoid piracy and racey method shadowing

### DIFF
--- a/ext/JACCAMDGPU/JACCAMDGPU.jl
+++ b/ext/JACCAMDGPU/JACCAMDGPU.jl
@@ -9,7 +9,7 @@ include("array.jl")
 include("JACCEXPERIMENTAL.jl")
 using .experimental
 
-function JACC.parallel_for(N::I, f::F, x...) where {I <: Integer, F <: Function}
+function JACC.parallel_for(::Val{:amdgpu}, N::I, f::F, x...) where {I <: Integer, F <: Function}
     numThreads = 512
     threads = min(N, numThreads)
     blocks = ceil(Int, N / threads)
@@ -21,7 +21,7 @@ function JACC.parallel_for(N::I, f::F, x...) where {I <: Integer, F <: Function}
 end
 
 function JACC.parallel_for(
-        (M, N)::Tuple{I, I}, f::F, x...) where {I <: Integer, F <: Function}
+        ::Val{:amdgpu}, (M, N)::Tuple{I, I}, f::F, x...) where {I <: Integer, F <: Function}
     numThreads = 16
     Mthreads = min(M, numThreads)
     Nthreads = min(N, numThreads)
@@ -35,7 +35,7 @@ function JACC.parallel_for(
 end
 
 function JACC.parallel_for(
-        (L, M, N)::Tuple{I, I, I}, f::F, x...) where {
+        ::Val{:amdgpu}, (L, M, N)::Tuple{I, I, I}, f::F, x...) where {
         I <: Integer, F <: Function}
     numThreads = 32
     Lthreads = min(L, numThreads)
@@ -52,7 +52,7 @@ function JACC.parallel_for(
 end
 
 function JACC.parallel_reduce(
-        N::I, f::F, x...) where {I <: Integer, F <: Function}
+        ::Val{:amdgpu}, N::I, f::F, x...) where {I <: Integer, F <: Function}
     numThreads = 512
     threads = min(N, numThreads)
     blocks = ceil(Int, N / threads)
@@ -68,7 +68,7 @@ function JACC.parallel_reduce(
 end
 
 function JACC.parallel_reduce(
-        (M, N)::Tuple{I, I}, f::F, x...) where {I <: Integer, F <: Function}
+        ::Val{:amdgpu}, (M, N)::Tuple{I, I}, f::F, x...) where {I <: Integer, F <: Function}
     numThreads = 16
     Mthreads = min(M, numThreads)
     Nthreads = min(N, numThreads)
@@ -389,9 +389,6 @@ function JACC.shared(x::ROCDeviceArray{T,N}) where {T,N}
   return shmem
 end
 
-
-function __init__()
-    const JACC.Array = AMDGPU.ROCArray{T, N} where {T, N}
-end
+JACC.array_type(::Val{:amdgpu}) = AMDGPU.ROCArray{T, N} where {T, N}
 
 end # module JACCAMDGPU

--- a/ext/JACCAMDGPU/array.jl
+++ b/ext/JACCAMDGPU/array.jl
@@ -1,8 +1,8 @@
 
-function JACC.zeros(T, dims...)
+function JACC.zeros(::Val{:amdgpu}, T, dims...)
     return AMDGPU.zeros(T, dims...)
 end
 
-function JACC.ones(T, dims...)
+function JACC.ones(::Val{:amdgpu}, T, dims...)
     return AMDGPU.ones(T, dims...)
 end

--- a/ext/JACCCUDA/JACCCUDA.jl
+++ b/ext/JACCCUDA/JACCCUDA.jl
@@ -13,7 +13,7 @@ using .multi
 include("JACCEXPERIMENTAL.jl")
 using .experimental
 
-function JACC.parallel_for(N::I, f::F, x...) where {I <: Integer, F <: Function}
+function JACC.parallel_for(::Val{:cuda}, N::I, f::F, x...) where {I <: Integer, F <: Function}
     #parallel_args = (N, f, x...)
     #parallel_kargs = cudaconvert.(parallel_args)
     #parallel_tt = Tuple{Core.Typeof.(parallel_kargs)...}
@@ -28,7 +28,7 @@ function JACC.parallel_for(N::I, f::F, x...) where {I <: Integer, F <: Function}
 end
 
 function JACC.parallel_for(
-        (M, N)::Tuple{I, I}, f::F, x...) where {I <: Integer, F <: Function}
+        ::Val{:cuda}, (M, N)::Tuple{I, I}, f::F, x...) where {I <: Integer, F <: Function}
     #To use JACC.shared, it is recommended to use a high number of threads per block to maximize the
     # potential benefit from using shared memory.
     #numThreads = 32
@@ -42,7 +42,7 @@ function JACC.parallel_for(
 end
 
 function JACC.parallel_for(
-        (L, M, N)::Tuple{I, I, I}, f::F, x...) where {
+        ::Val{:cuda}, (L, M, N)::Tuple{I, I, I}, f::F, x...) where {
         I <: Integer, F <: Function}
     #To use JACC.shared, it is recommended to use a high number of threads per block to maximize the
     # potential benefit from using shared memory.
@@ -58,7 +58,7 @@ function JACC.parallel_for(
 end
 
 function JACC.parallel_reduce(
-        N::I, f::F, x...) where {I <: Integer, F <: Function}
+        ::Val{:cuda}, N::I, f::F, x...) where {I <: Integer, F <: Function}
     numThreads = 512
     threads = min(N, numThreads)
     blocks = ceil(Int, N / threads)
@@ -72,7 +72,7 @@ function JACC.parallel_reduce(
 end
 
 function JACC.parallel_reduce(
-        (M, N)::Tuple{I, I}, f::F, x...) where {I <: Integer, F <: Function}
+        ::Val{:cuda}, (M, N)::Tuple{I, I}, f::F, x...) where {I <: Integer, F <: Function}
     numThreads = 16
     Mthreads = min(M, numThreads)
     Nthreads = min(N, numThreads)
@@ -402,9 +402,6 @@ function JACC.shared(x::CuDeviceArray{T,N}) where {T,N}
   return shmem
 end
 
-
-function __init__()
-    const JACC.Array = CUDA.CuArray{T, N} where {T, N}
-end
+JACC.array_type(::Val{:cuda}) = CUDA.CuArray{T, N} where {T, N}
 
 end # module JACCCUDA

--- a/ext/JACCCUDA/array.jl
+++ b/ext/JACCCUDA/array.jl
@@ -1,8 +1,8 @@
 
-function JACC.zeros(T, dims...)
+function JACC.zeros(::Val{:cuda}, T, dims...)
     return CUDA.zeros(T, dims...)
 end
 
-function JACC.ones(T, dims...)
+function JACC.ones(::Val{:cuda}, T, dims...)
     return CUDA.ones(T, dims...)
 end

--- a/ext/JACCONEAPI/JACCONEAPI.jl
+++ b/ext/JACCONEAPI/JACCONEAPI.jl
@@ -9,7 +9,7 @@ include("array.jl")
 include("JACCEXPERIMENTAL.jl")
 using .experimental
 
-function JACC.parallel_for(N::I, f::F, x...) where {I <: Integer, F <: Function}
+function JACC.parallel_for(::Val{:oneapi}, N::I, f::F, x...) where {I <: Integer, F <: Function}
     #maxPossibleItems = oneAPI.oneL0.compute_properties(device().maxTotalGroupSize)
     maxPossibleItems = 256
     items = min(N, maxPossibleItems)
@@ -22,7 +22,7 @@ function JACC.parallel_for(N::I, f::F, x...) where {I <: Integer, F <: Function}
 end
 
 function JACC.parallel_for(
-        (M, N)::Tuple{I, I}, f::F, x...) where {I <: Integer, F <: Function}
+        ::Val{:oneapi}, (M, N)::Tuple{I, I}, f::F, x...) where {I <: Integer, F <: Function}
     maxPossibleItems = 16
     Mitems = min(M, maxPossibleItems)
     Nitems = min(N, maxPossibleItems)
@@ -33,7 +33,7 @@ function JACC.parallel_for(
 end
 
 function JACC.parallel_for(
-        (L, M, N)::Tuple{I, I}, f::F, x...) where {I <: Integer, F <: Function}
+        ::Val{:oneapi}, (L, M, N)::Tuple{I, I}, f::F, x...) where {I <: Integer, F <: Function}
     maxPossibleItems = 16
     Litems = min(M, maxPossibleItems)
     Mitems = min(M, maxPossibleItems)
@@ -47,7 +47,7 @@ function JACC.parallel_for(
 end
 
 function JACC.parallel_reduce(
-        N::I, f::F, x...) where {I <: Integer, F <: Function}
+        ::Val{:oneapi}, N::I, f::F, x...) where {I <: Integer, F <: Function}
     numItems = 256
     items = min(N, numItems)
     groups = ceil(Int, N / items)
@@ -60,7 +60,7 @@ function JACC.parallel_reduce(
 end
 
 function JACC.parallel_reduce(
-        (M, N)::Tuple{I, I}, f::F, x...) where {I <: Integer, F <: Function}
+        ::Val{:oneapi}, (M, N)::Tuple{I, I}, f::F, x...) where {I <: Integer, F <: Function}
     numItems = 16
     Mitems = min(M, numItems)
     Nitems = min(N, numItems)
@@ -379,8 +379,6 @@ function JACC.shared(x::oneDeviceArray{T,N}) where {T,N}
   return shmem
 end
 
-function __init__()
-    const JACC.Array = oneAPI.oneArray{T, N} where {T, N}
-end
+JACC.array_type(::Val{:oneapi}) = oneAPI.oneArray{T, N} where {T, N}
 
 end # module JACCONEAPI

--- a/ext/JACCONEAPI/array.jl
+++ b/ext/JACCONEAPI/array.jl
@@ -1,8 +1,8 @@
 
-function JACC.zeros(T, dims...)
+function JACC.zeros(::Val{:oneapi}, T, dims...)
     return oneAPI.zeros(T, dims...)
 end
 
-function JACC.ones(T, dims...)
+function JACC.ones(::Val{:oneapi}, T, dims...)
     return oneAPI.ones(T, dims...)
 end

--- a/src/JACCMULTI.jl
+++ b/src/JACCMULTI.jl
@@ -3,22 +3,40 @@ module multi
 using JACC
 
 function Array(x::Base.Array{T,N}) where {T,N}
+    return Array(JACCPreferences._backend_dispatchable, x)
+end
+function Array(::Val{:threads}, x::Base.Array{T,N}) where {T,N}
   return x
 end
 
 function copy(x::Vector{Any}, y::Vector{Any})
+    return copy(JACCPreferences._backend_dispatchable, x, y)
+end
+function copy(::Val{:threads}, x::Vector{Any}, y::Vector{Any})
 end
 
 function parallel_for(N::I, f::F, x...) where {I <: Integer, F <: Function}
+    return parallel_for(JACCPreferences._backend_dispatchable, N, f, x...)
+end
+function parallel_for(::Val{:threads}, N::I, f::F, x...) where {I <: Integer, F <: Function}
 end
 
-function parallel_for((M, N)::Tuple{I,I}, f::F, x...) where {I <: Integer, F <: Function}
+function parallel_for((M, N)::Tuple{I, I}, f::F, x...) where {I <: Integer, F <: Function}
+    return parallel_for(JACCPreferences._backend_dispatchable, (M, N), f, x...)
+end
+function parallel_for(::Val{:threads}, (M, N)::Tuple{I,I}, f::F, x...) where {I <: Integer, F <: Function}
 end
 
 function parallel_reduce(N::I, f::F, x...) where {I <: Integer, F <: Function}
+    return parallel_reduce(JACCPreferences._backend_dispatchable, N, f, x...)
+end
+function parallel_reduce(::Val{:threads}, N::I, f::F, x...) where {I <: Integer, F <: Function}
 end
 
 function parallel_reduce((M, N)::Tuple{I, I}, f::F, x...) where {I <: Integer, F <: Function}
+    return parallel_reduce(JACCPreferences._backend_dispatchable, (M, N), f, x...)
+end
+function parallel_reduce(::Val{:threads}, (M, N)::Tuple{I, I}, f::F, x...) where {I <: Integer, F <: Function}
 end
 
 end # module multi

--- a/src/JACCPreferences.jl
+++ b/src/JACCPreferences.jl
@@ -16,5 +16,6 @@ function set_backend(new_backend::String)
 end
 
 const backend = @load_preference("backend", "threads")
+const _backend_dispatchable = Val{Symbol(backend)}()
 
 end # module JACCPreferences

--- a/src/array.jl
+++ b/src/array.jl
@@ -1,8 +1,10 @@
 
-function zeros(T, dims...)
+zeros(T, dims...) = zeros(JACCPrefereces._backend_dispatchable, T, dims...)
+function zeros(::Val{:threads}, T, dims...)
     return Base.zeros(T, dims...)
 end
 
-function ones(T, dims...)
+ones(T, dims...) = ones(JACCPrefereces._backend_dispatchable, T, dims...)
+function ones(::Val{:threads}, T, dims...)
     return Base.ones(T, dims...)
 end


### PR DESCRIPTION
This PR implements a mechanism for utilizing the selected backend to create a dispatchable key (turning "cuda" into `Val{:cuda}()`), so that extensions do not need to shadow/pirate JACC's own methods. This should make it safe to load CUDA, AMDGPU, and oneAPI all at once (or any such combination), yet have things still dispatch correctly based on the selected backend.

~Unfortunately, this cannot work for `JACC.Array` as-is, because extensions are loaded after `__init__` is called. So instead, I propose moving the setting of `JACC.Array` into an `init()` function that users must call to initialize JACC. There is not really any nice way to do this that I can think of - maybe if module property access becomes something we can control (like how we can overload `getproperty`), then it will be possible to remove the need for `init()`.~ Fixed!

Although this does work for `using AMDGPU, JACC` for me locally, I still have to wire up the tests for this, and I haven't tested any of the functionality (as my ROCm libraries are a mess on my local system). ~Hence this is currently a draft PR.~