### PR TITLE
Added JACC.multi implementation for the AMDGPU backend, non-included …

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["pedrovalerolara <valerolarap@ornl.gov>", "williamfgc <williamfgc@yah
 version = "0.0.5"
 
 [deps]
+AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
 Atomix = "a9b6321e-bd34-4604-b9c9-b65b8de01458"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 
@@ -18,7 +19,7 @@ JACCCUDA = ["CUDA"]
 JACCONEAPI = ["oneAPI"]
 
 [compat]
-AMDGPU = "0.8"
+AMDGPU = "1.0"
 Atomix = "0.1"
 CUDA = "5"
 Preferences = "1.4.0"

--- a/ext/JACCAMDGPU/JACCAMDGPU.jl
+++ b/ext/JACCAMDGPU/JACCAMDGPU.jl
@@ -5,6 +5,9 @@ using JACC, AMDGPU
 # overloaded array functions
 include("array.jl")
 
+include("JACCMULTI.jl")
+using .multi
+
 # overloaded experimental functions
 include("JACCEXPERIMENTAL.jl")
 using .experimental

--- a/ext/JACCAMDGPU/JACCMULTI.jl
+++ b/ext/JACCAMDGPU/JACCMULTI.jl
@@ -1,53 +1,65 @@
 module multi
 
-using JACC, CUDA
+using JACC, AMDGPU
 
 function JACC.multi.ndev()
-  return length(devices())
+  return length(AMDGPU.devices())
+end
+
+function get_portable_rocarray(x::Base.Array{T, N}) where {T, N}
+    dims = size(x)
+    bytesize = sizeof(T) * prod(dims)
+    buf = AMDGPU.Mem.HostBuffer(bytesize, AMDGPU.HIP.hipHostAllocPortable)
+    ROCArray{T, N}(AMDGPU.GPUArrays.DataRef(AMDGPU.pool_free, AMDGPU.Managed(buf)), dims)
 end
 
 function JACC.multi.Array(x::Base.Array{T,N}) where {T,N}
 
-  ndev = length(devices())
   ret = Vector{Any}(undef, 2)  
+  ndev = length(AMDGPU.devices())
 
   if ndims(x) == 1
 
-    device!(0)
+    AMDGPU.device!(AMDGPU.device(1))
     s_array = length(x)
     s_arrays = ceil(Int, s_array/ndev)
+    #println(s_arrays)
     array_ret = Vector{Any}(undef, ndev)  
-    pointer_ret = Vector{CuDeviceVector{T,CUDA.AS.Global}}(undef, ndev)  
+    pointer_ret = Vector{AMDGPU.Device.ROCDeviceVector{T,AMDGPU.Device.AS.Global}}(undef, ndev)  
 
     for i in 1:ndev
-      device!(i-1)
-      array_ret[i] = CuArray(x[((i-1)*s_arrays)+1:i*s_arrays])
-      pointer_ret[i] = cudaconvert(array_ret[i])
+      AMDGPU.device!(AMDGPU.device(i))
+      array_ret[i] = ROCArray(x[((i-1)*s_arrays)+1:i*s_arrays])
+      pointer_ret[i] = AMDGPU.rocconvert(array_ret[i])
     end
-  
-    device!(0)
-    cuda_pointer_ret = CuArray(pointer_ret)
-    ret[1] = cuda_pointer_ret
+    
+    AMDGPU.device!(AMDGPU.device(1))
+    #amdgpu_pointer_ret = ROCArray(pointer_ret)
+    amdgpu_pointer_ret = get_portable_rocarray(pointer_ret)
+    copyto!(amdgpu_pointer_ret, pointer_ret)
+    ret[1] = amdgpu_pointer_ret
     ret[2] = array_ret
 
   elseif ndims(x) == 2
 
-    device!(0)
+    AMDGPU.device!(AMDGPU.device(1))
+    #s_row_array = size(x,1)
     s_col_array = size(x,2)
     s_col_arrays = ceil(Int, s_col_array/ndev)
     array_ret = Vector{Any}(undef, ndev)  
-    pointer_ret = Vector{CuDeviceMatrix{T,CUDA.AS.Global}}(undef, ndev)  
+    pointer_ret = Vector{AMDGPU.Device.ROCDeviceMatrix{T,1}}(undef, ndev)  
 
     for i in 1:ndev
-      device!(i-1)
-      array_ret[i] = CuArray(x[:,((i-1)*s_col_arrays)+1:i*s_col_arrays])
-      pointer_ret[i] = cudaconvert(array_ret[i])
+      AMDGPU.device!(AMDGPU.device(i))
+      array_ret[i] = ROCArray(x[:,((i-1)*s_col_arrays)+1:i*s_col_arrays])
+      pointer_ret[i] = AMDGPU.rocconvert(array_ret[i])
     end
   
-    device!(0)
-  
-    cuda_pointer_ret = CuArray(pointer_ret)
-    ret[1] = cuda_pointer_ret
+    AMDGPU.device!(AMDGPU.device(1))
+    #amdgpu_pointer_ret = ROCArray(pointer_ret)
+    amdgpu_pointer_ret = get_portable_rocarray(pointer_ret)
+    copyto!(amdgpu_pointer_ret, pointer_ret)
+    ret[1] = amdgpu_pointer_ret
     ret[2] = array_ret
 
   end
@@ -57,96 +69,55 @@ function JACC.multi.Array(x::Base.Array{T,N}) where {T,N}
 end
 
 function JACC.multi.copy(x::Vector{Any}, y::Vector{Any})
-   device!(0) 
-   ndev = length(devices())
-  
+   
+   AMDGPU.device!(AMDGPU.device(1))
+   ndev = length(AMDGPU.devices())
+
    for i in 1:ndev
-       device!(i-1)
+       AMDGPU.device!(AMDGPU.device(i))
        size = length(x[2][i])
        numThreads = 512
        threads = min(size, numThreads)
        blocks = ceil(Int, size / threads)
-       @cuda threads=threads blocks=blocks _multi_copy(i, x[1], y[1])
+       @roc groupsize=threads gridsize=blocks _multi_copy(i, x[1], y[1])
+       #AMDGPU.synchronize()
    end
-    
-   for i in 1:ndev
-      device!(i-1)
-      synchronize()
-   end 
 
-   device!(0) 
-  
+   for i in 1:ndev
+      AMDGPU.device!(AMDGPU.device(i))
+      AMDGPU.synchronize()
+   end
+
+   AMDGPU.device!(AMDGPU.device(1))
+
 end
 
 function JACC.multi.parallel_for(N::I, f::F, x...) where {I <: Integer, F <: Function}
 
-  device!(0)
-  ndev = length(devices())
+  ndev = length(AMDGPU.devices())
   N_multi = ceil(Int, N/ndev)
   numThreads = 256
   threads = min(N_multi, numThreads)
   blocks = ceil(Int, N_multi / threads)
-
+  
   for i in 1:ndev
-    device!(i-1)
+    AMDGPU.device!(AMDGPU.device(i))
     dev_id = i
-    @cuda threads=threads blocks=blocks _multi_parallel_for_cuda(N_multi, dev_id, f, x...)
+    @roc groupsize=threads gridsize=blocks _multi_parallel_for_amdgpu(N_multi, dev_id, f, x...)
   end
 
   for i in 1:ndev
-    device!(i-1)
-    synchronize()
+    AMDGPU.device!(AMDGPU.device(i))
+    AMDGPU.synchronize()
   end
   
-  device!(0)
+  AMDGPU.device!(AMDGPU.device(1))
 
 end
 
-function JACC.multi.parallel_reduce(N::I, f::F, x...) where {I <: Integer, F <: Function}
-    
-    device!(0)
-    ndev = length(devices())
-    ret = Vector{Any}(undef, ndev)  
-    rret = Vector{Any}(undef, ndev)  
-    N_multi = ceil(Int, N/ndev)
-    numThreads = 512
-    threads = min(N_multi, numThreads)
-    blocks = ceil(Int, N_multi / threads)
-    final_rret = CUDA.zeros(Float64, 1)
-    
-    for i in 1:ndev
-      device!(i-1)
-      ret[i] = CUDA.zeros(Float64, blocks)
-      rret[i] = CUDA.zeros(Float64, 1)
-    end
+function JACC.multi.parallel_for((M, N)::Tuple{I,I}, f::F, x...) where {I <: Integer, F <: Function}
 
-    for i in 1:ndev
-      device!(i-1)
-      dev_id = i
-      @cuda threads=threads blocks=blocks shmem=512 * sizeof(Float64) _multi_parallel_reduce_cuda(
-        N_multi, dev_id, ret[i], f, x...)
-      @cuda threads=threads blocks=1 shmem=512 * sizeof(Float64) _multi_reduce_kernel_cuda(
-        blocks, ret[i], rret[i])
-    end
-
-    for i in 1:ndev
-      device!(i-1)
-      synchronize()
-    end
-    
-    for i in 1:ndev
-      final_rret += rret[i]
-    end
-  
-    device!(0)
-    
-    return final_rret
-end
-
-function JACC.multi.parallel_for(
-         (M, N)::Tuple{I,I}, f::F, x...) where {I <: Integer, F <: Function}
-
-  ndev = length(devices())
+  ndev = length(AMDGPU.devices())
   N_multi = ceil(Int, N/ndev)
   numThreads = 16
   Mthreads = min(M, numThreads)
@@ -155,128 +126,198 @@ function JACC.multi.parallel_for(
   Nblocks = ceil(Int, N_multi / Nthreads)
 
   for i in 1:ndev
-    device!(i-1)
+    AMDGPU.device!(AMDGPU.device(i))
     dev_id = i
-    @cuda threads=(Mthreads, Nthreads) blocks=(Mblocks, Nblocks) _multi_parallel_for_cuda_MN(M, N_multi, dev_id, f, x...)
+    @roc groupsize=(Mthreads, Nthreads) gridsize=(Mblocks, Nblocks) _multi_parallel_for_amdgpu_MN(M, N_multi, dev_id, f, x...)
   end
 
   for i in 1:ndev
-    device!(i-1)
-    synchronize()
+    AMDGPU.device!(AMDGPU.device(i))
+    AMDGPU.synchronize()
   end
   
-  device!(0)
+  AMDGPU.device!(AMDGPU.device(1))
 
+end
+
+function JACC.multi.parallel_reduce(N::I, f::F, x...) where {I <: Integer, F <: Function}
+
+    AMDGPU.device!(AMDGPU.device(1))
+    ndev = length(AMDGPU.devices())
+    ret = Vector{Any}(undef, ndev)
+    rret = Vector{Any}(undef, ndev)
+    N_multi = ceil(Int, N/ndev)
+    numThreads = 512
+    threads = min(N_multi, numThreads)
+    blocks = ceil(Int, N_multi / threads)
+    final_rret = AMDGPU.zeros(Float64, 1)
+
+    for i in 1:ndev
+      AMDGPU.device!(AMDGPU.device(i))
+      ret[i] = AMDGPU.zeros(Float64, blocks)
+      rret[i] = AMDGPU.zeros(Float64, 1)
+    end
+
+    for i in 1:ndev
+      AMDGPU.device!(AMDGPU.device(i))
+      dev_id = i
+      @roc groupsize=threads gridsize=blocks _multi_parallel_reduce_amdgpu(
+        N_multi, dev_id, ret[i], f, x...)
+    end
+    for i in 1:ndev
+      AMDGPU.device!(AMDGPU.device(i))
+      dev_id = i
+      @roc groupsize=threads gridsize=1 _multi_reduce_kernel_amdgpu(
+        blocks, ret[i], rret[i])
+    end
+
+    for i in 1:ndev
+      AMDGPU.device!(AMDGPU.device(i))
+      AMDGPU.synchronize()
+    end
+
+    tmp_rret = Vector{Any}(undef, ndev)
+    tmp_final_rret = 0.0
+
+    for i in 1:ndev
+      tmp_rret[i] = zeros(Float64, 1)
+      AMDGPU.device!(AMDGPU.device(i))
+      tmp_rret[i] = Base.Array(rret[i])
+      #println(tmp_rret[i][1])
+    end
+
+    AMDGPU.device!(AMDGPU.device(1))
+    for i in 1:ndev
+      tmp_final_rret += tmp_rret[i][1]
+    end
+    final_rret = tmp_final_rret
+
+    return final_rret
 end
 
 function JACC.multi.parallel_reduce(
         (M, N)::Tuple{I, I}, f::F, x...) where {I <: Integer, F <: Function}
 
   ndev = length(devices())
-  ret = Vector{Any}(undef, ndev)  
-  rret = Vector{Any}(undef, ndev)  
+  ret = Vector{Any}(undef, ndev)
+  rret = Vector{Any}(undef, ndev)
   N_multi = ceil(Int, N/ndev)
   numThreads = 16
   Mthreads = min(M, numThreads)
   Nthreads = min(N_multi, numThreads)
   Mblocks = ceil(Int, M / Mthreads)
   Nblocks = ceil(Int, N_multi / Nthreads)
-  final_rret = CUDA.zeros(Float64, 1)
-  
+  final_rret = AMDGPU.zeros(Float64, 1)
+
   for i in 1:ndev
-    device!(i-1)
-    ret[i] = CUDA.zeros(Float64, (Mblocks, Nblocks))
-    rret[i] = CUDA.zeros(Float64, 1)
+    AMDGPU.device!(AMDGPU.device(i))
+    ret[i] = AMDGPU.zeros(Float64, (Mblocks, Nblocks))
+    rret[i] = AMDGPU.zeros(Float64, 1)
   end
-    
+
   for i in 1:ndev
-    device!(i-1)
+	  AMDGPU.device!(AMDGPU.device(i))
     dev_id = i
 
-    @cuda threads=(Mthreads, Nthreads) blocks=(Mblocks, Nblocks) shmem=16 * 16 * sizeof(Float64) _multi_parallel_reduce_cuda_MN(
+    @roc groupsize=(Mthreads, Nthreads) gridsize=(Mblocks, Nblocks) _multi_parallel_reduce_amdgpu_MN(
         (M, N_multi), dev_id, ret[i], f, x...)
-    
-    @cuda threads=(Mthreads, Nthreads) blocks=(1, 1) shmem=16 * 16 *sizeof(Float64) _multi_reduce_kernel_cuda_MN(
+
+    @roc groupsize=(Mthreads, Nthreads) gridsize=(1, 1) _multi_reduce_kernel_amdgpu_MN(
         (Mblocks, Nblocks), ret[i], rret[i])
   end
-    
+
   for i in 1:ndev
-    device!(i-1)
-    synchronize()
-  end
-    
-  for i in 1:ndev
-    final_rret += rret[i]
+    AMDGPU.device!(AMDGPU.device(i))
+    AMDGPU.synchronize()
   end
   
-  device!(0)
-    
+  tmp = zeros(ndev)
+
+  for i in 1:ndev
+    AMDGPU.device!(AMDGPU.device(i))
+    tmp[i] = Base.Array(rret[i])
+  end
+
+  AMDGPU.device!(AMDGPU.device(1))
+  for i in 1:ndev
+    final_rret += tmp[i]
+  end
+
   return final_rret
 
 end
 
-function _multi_parallel_for_cuda(N, dev_id, f, x...)
-    i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+function _multi_parallel_for_amdgpu(N, dev_id, f, x...)
+    i = (workgroupIdx().x - 1) * workgroupDim().x + workitemIdx().x
     if i <= N
         f(dev_id, i, x...)
     end
     return nothing
 end
 
-function _multi_parallel_reduce_cuda(N, dev_id, ret, f, x...)
-    shared_mem = @cuDynamicSharedMem(Float64, 512)
-    i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
-    ti = threadIdx().x
+function _multi_parallel_for_amdgpu_MN(M, N, dev_id, f, x...)
+    i = (workgroupIdx().x - 1) * workgroupDim().x + workitemIdx().x
+    j = (workgroupIdx().y - 1) * workgroupDim().y + workitemIdx().y
+    if (i <= M) && (j <= N)
+        f(dev_id, i, j, x...)
+    end
+    return nothing
+end
+
+function _multi_parallel_reduce_amdgpu(N, dev_id, ret, f, x...)
+    shared_mem = @ROCStaticLocalArray(Float64, 512)
+    i = (workgroupIdx().x - 1) * workgroupDim().x + workitemIdx().x
+    ti = workitemIdx().x
     tmp::Float64 = 0.0
     shared_mem[ti] = 0.0
 
     if i <= N
         tmp = @inbounds f(dev_id, i, x...)
-        shared_mem[threadIdx().x] = tmp
+        shared_mem[workitemIdx().x] = tmp
     end
-    sync_threads()
+    AMDGPU.sync_workgroup()
     if (ti <= 256)
         shared_mem[ti] += shared_mem[ti + 256]
     end
-    sync_threads()
+    AMDGPU.sync_workgroup()
     if (ti <= 128)
         shared_mem[ti] += shared_mem[ti + 128]
     end
-    sync_threads()
+    AMDGPU.sync_workgroup()
     if (ti <= 64)
         shared_mem[ti] += shared_mem[ti + 64]
     end
-    sync_threads()
+    AMDGPU.sync_workgroup()
     if (ti <= 32)
         shared_mem[ti] += shared_mem[ti + 32]
     end
-    sync_threads()
+    AMDGPU.sync_workgroup()
     if (ti <= 16)
         shared_mem[ti] += shared_mem[ti + 16]
     end
-    sync_threads()
+    AMDGPU.sync_workgroup()
     if (ti <= 8)
         shared_mem[ti] += shared_mem[ti + 8]
     end
-    sync_threads()
+    AMDGPU.sync_workgroup()
     if (ti <= 4)
         shared_mem[ti] += shared_mem[ti + 4]
     end
-    sync_threads()
+    AMDGPU.sync_workgroup()
     if (ti <= 2)
         shared_mem[ti] += shared_mem[ti + 2]
     end
-    sync_threads()
+    AMDGPU.sync_workgroup()
     if (ti == 1)
         shared_mem[ti] += shared_mem[ti + 1]
-        ret[blockIdx().x] = shared_mem[ti]
+	ret[workgroupIdx().x] = shared_mem[ti]
     end
     return nothing
 end
 
-function _multi_reduce_kernel_cuda(N, red, ret)
-    shared_mem = @cuDynamicSharedMem(Float64, 512)
-    i = threadIdx().x
+function _multi_reduce_kernel_amdgpu(N, red, ret)
+    shared_mem = @ROCStaticLocalArray(Float64, 512)
+    i = workitemIdx().x
     ii = i
     tmp::Float64 = 0.0
     if N > 512
@@ -287,64 +328,56 @@ function _multi_reduce_kernel_cuda(N, red, ret)
     elseif (i <= N)
           tmp = @inbounds red[i]
     end
-    shared_mem[threadIdx().x] = tmp
-    sync_threads()
+    shared_mem[workitemIdx().x] = tmp
+    AMDGPU.sync_workgroup()
     if (i <= 256)
         shared_mem[i] += shared_mem[i + 256]
     end
-    sync_threads()
+    AMDGPU.sync_workgroup()
     if (i <= 128)
         shared_mem[i] += shared_mem[i + 128]
     end
-    sync_threads()
+    AMDGPU.sync_workgroup()
     if (i <= 64)
         shared_mem[i] += shared_mem[i + 64]
     end
-    sync_threads()
+    AMDGPU.sync_workgroup()
     if (i <= 32)
         shared_mem[i] += shared_mem[i + 32]
     end
-    sync_threads()
+    AMDGPU.sync_workgroup()
     if (i <= 16)
         shared_mem[i] += shared_mem[i + 16]
     end
-    sync_threads()
+    AMDGPU.sync_workgroup()
     if (i <= 8)
         shared_mem[i] += shared_mem[i + 8]
     end
-    sync_threads()
+    AMDGPU.sync_workgroup()
     if (i <= 4)
         shared_mem[i] += shared_mem[i + 4]
     end
-    sync_threads()
+    AMDGPU.sync_workgroup()
     if (i <= 2)
         shared_mem[i] += shared_mem[i + 2]
     end
-    sync_threads()
+    AMDGPU.sync_workgroup()
     if (i == 1)
         shared_mem[i] += shared_mem[i + 1]
         ret[1] = shared_mem[1]
     end
+    AMDGPU.sync_workgroup()
     return nothing
 end
 
-function _multi_parallel_for_cuda_MN(M, N, dev_id, f, x...)
-    i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
-    j = (blockIdx().y - 1) * blockDim().y + threadIdx().y
-    if (i <= M) && (j <= N)
-        f(dev_id, i, j, x...)
-    end
-    return nothing
-end
-
-function _multi_parallel_reduce_cuda_MN((M, N), dev_id, ret, f, x...)
-    shared_mem = @cuDynamicSharedMem(Float64, 16*16)
-    i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
-    j = (blockIdx().y - 1) * blockDim().y + threadIdx().y
-    ti = threadIdx().x
-    tj = threadIdx().y
-    bi = blockIdx().x
-    bj = blockIdx().y
+function _multi_parallel_reduce_amdgpu_MN((M, N), dev_id, ret, f, x...)
+    shared_mem = @ROCStaticLocalArray(Float64, 16*16)
+    i = (workgroupIdx().x - 1) * workgroupDim().x + workitemIdx().x
+    j = (workgroupIdx().y - 1) * workgroupDim().y + workitemIdx().y
+    ti = workitemIdx().x
+    tj = workitemIdx().y
+    bi = workgroupIdx().x
+    bj = workgroupIdx().y
 
     tmp::Float64 = 0.0
     shared_mem[((ti - 1) * 16) + tj] = tmp
@@ -353,25 +386,25 @@ function _multi_parallel_reduce_cuda_MN((M, N), dev_id, ret, f, x...)
         tmp = @inbounds f(dev_id, i, j, x...)
         shared_mem[(ti - 1) * 16 + tj] = tmp
     end
-    sync_threads()
+    AMDGPU.sync_workgroup()
     if (ti <= 8 && tj <= 8 && ti + 8 <= M && tj + 8 <= N)
         shared_mem[((ti - 1) * 16) + tj] += shared_mem[((ti + 7) * 16) + (tj + 8)]
         shared_mem[((ti - 1) * 16) + tj] += shared_mem[((ti - 1) * 16) + (tj + 8)]
         shared_mem[((ti - 1) * 16) + tj] += shared_mem[((ti + 7) * 16) + tj]
     end
-    sync_threads()
+    AMDGPU.sync_workgroup()
     if (ti <= 4 && tj <= 4 && ti + 4 <= M && tj + 4 <= N)
         shared_mem[((ti - 1) * 16) + tj] += shared_mem[((ti + 3) * 16) + (tj + 4)]
         shared_mem[((ti - 1) * 16) + tj] += shared_mem[((ti - 1) * 16) + (tj + 4)]
         shared_mem[((ti - 1) * 16) + tj] += shared_mem[((ti + 3) * 16) + tj]
     end
-    sync_threads()
+    AMDGPU.sync_workgroup()
     if (ti <= 2 && tj <= 2 && ti + 2 <= M && tj + 2 <= N)
         shared_mem[((ti - 1) * 16) + tj] += shared_mem[((ti + 1) * 16) + (tj + 2)]
         shared_mem[((ti - 1) * 16) + tj] += shared_mem[((ti - 1) * 16) + (tj + 2)]
         shared_mem[((ti - 1) * 16) + tj] += shared_mem[((ti + 1) * 16) + tj]
     end
-    sync_threads()
+    AMDGPU.sync_workgroup()
     if (ti == 1 && tj == 1 && ti + 1 <= M && tj + 1 <= N)
         shared_mem[((ti - 1) * 16) + tj] += shared_mem[ti * 16 + (tj + 1)]
         shared_mem[((ti - 1) * 16) + tj] += shared_mem[((ti - 1) * 16) + (tj + 1)]
@@ -381,10 +414,10 @@ function _multi_parallel_reduce_cuda_MN((M, N), dev_id, ret, f, x...)
     return nothing
 end
 
-function _multi_reduce_kernel_cuda_MN((M, N), red, ret)
-    shared_mem = @cuDynamicSharedMem(Float64, 16*16)
-    i = threadIdx().x
-    j = threadIdx().y
+function _multi_reduce_kernel_amdgpu_MN((M, N), red, ret)
+    shared_mem = @ROCStaticLocalArray(Float64, 16*16)
+    i = workitemIdx().x
+    j = workitemIdx().y
     ii = i
     jj = j
 
@@ -393,7 +426,7 @@ function _multi_reduce_kernel_cuda_MN((M, N), red, ret)
 
     if M > 16 && N > 16
         while ii <= M
-            jj = threadIdx().y
+            jj = workitemIdx().y
             while jj <= N
                 tmp = tmp + @inbounds red[ii, jj]
                 jj += 16
@@ -417,7 +450,7 @@ function _multi_reduce_kernel_cuda_MN((M, N), red, ret)
     end
     shared_mem[(i - 1) * 16 + j] = tmp
     red[i, j] = shared_mem[(i - 1) * 16 + j]
-    sync_threads()
+    AMDGPU.sync_workgroup()
     if (i <= 8 && j <= 8)
         if (i + 8 <= M && j + 8 <= N)
             shared_mem[((i - 1) * 16) + j] += shared_mem[((i + 7) * 16) + (j + 8)]
@@ -429,7 +462,7 @@ function _multi_reduce_kernel_cuda_MN((M, N), red, ret)
             shared_mem[((i - 1) * 16) + j] += shared_mem[((i + 7) * 16) + j]
         end
     end
-    sync_threads()
+    AMDGPU.sync_workgroup()
     if (i <= 4 && j <= 4)
         if (i + 4 <= M && j + 4 <= N)
             shared_mem[((i - 1) * 16) + j] += shared_mem[((i + 3) * 16) + (j + 4)]
@@ -441,7 +474,7 @@ function _multi_reduce_kernel_cuda_MN((M, N), red, ret)
             shared_mem[((i - 1) * 16) + j] += shared_mem[((i + 3) * 16) + j]
         end
     end
-    sync_threads()
+    AMDGPU.sync_workgroup()
     if (i <= 2 && j <= 2)
         if (i + 2 <= M && j + 2 <= N)
             shared_mem[((i - 1) * 16) + j] += shared_mem[((i + 1) * 16) + (j + 2)]
@@ -453,7 +486,7 @@ function _multi_reduce_kernel_cuda_MN((M, N), red, ret)
             shared_mem[((i - 1) * 16) + j] += shared_mem[((i + 1) * 16) + j]
         end
     end
-    sync_threads()
+    AMDGPU.sync_workgroup()
     if (i == 1 && j == 1)
         if (i + 1 <= M && j + 1 <= N)
             shared_mem[((i - 1) * 16) + j] += shared_mem[i * 16 + (j + 1)]
@@ -468,5 +501,8 @@ function _multi_reduce_kernel_cuda_MN((M, N), red, ret)
     end
     return nothing
 end
+
+
+
 
 end # module multi

--- a/ext/JACCCUDA/JACCCUDA.jl
+++ b/ext/JACCCUDA/JACCCUDA.jl
@@ -5,7 +5,6 @@ using JACC, CUDA
 # overloaded array functions
 include("array.jl")
 
-
 include("JACCMULTI.jl")
 using .multi
 

--- a/src/JACCMULTI.jl
+++ b/src/JACCMULTI.jl
@@ -2,6 +2,9 @@ module multi
 
 using JACC
 
+function ndev()
+end
+
 function Array(x::Base.Array{T,N}) where {T,N}
   return x
 end

--- a/test/tests_amdgpu.jl
+++ b/test/tests_amdgpu.jl
@@ -265,3 +265,44 @@ end
     C_expected = Float32(2.0) .* ones(Float32, L, M, N)
     @test Array(C)≈C_expected rtol=1e-5
 end
+
+#@testset "JACC.multi" begin
+
+#    x = ones(1_000)
+#    y = ones(1_000)
+#    jx = JACC.multi.Array(x)
+#    jy = JACC.multi.Array(y)
+#    jxresult = ones(1_000)
+#    alpha = 2.0
+
+#    function seq_axpy(N, alpha, x, y)
+#        for i in 1:N
+#            @inbounds x[i] += alpha * y[i]
+#        end
+#    end
+    
+#    function multi_axpy(dev_id, i, alpha, x, y)
+#	    @inbounds x[dev_id][i] += alpha * y[dev_id][i]
+#    end
+    
+#    function seq_dot(N, x, y)
+#        r = 0.0
+#        for i in 1:N
+#            @inbounds r += x[i] * y[i]
+#        end
+#        return r
+#    end
+
+#    function multi_dot(dev_id, i, x, y)
+#        @inbounds x[dev_id][i] * y[dev_id][i]
+#    end
+
+    #ref_result = seq_axpy(1_000, x, y)
+    #jresult = JACC.multi.parallel_reduce(1_000, multi_dot, jx[1], jy[1])
+#    seq_axpy(1_000, alpha, x, y)
+#    JACC.multi.parallel_for(1_000, multi_axpy, alpha, jx[1], jy[1])
+
+    #result = Base.Array(jresult)
+
+    #@test jresult[1]≈ref_result rtol=1e-8
+#end


### PR DESCRIPTION
Added JACC.multi implementation for the AMDGPU backend, non-included the special function for ghost cell management. Tests don't work, we need more than one GPU for this. I tested the test codes in Frontier. It worked well there. Also, the tests do not work on MI100-cousteau, even using the last version of AMDGPU. I changed Project. toml to include a more moderm version of AMDGPU.jl which we need for multi GPU support
