### PR TITLE
Added @init_backend for user convenience.

### DIFF
--- a/src/helper.jl
+++ b/src/helper.jl
@@ -12,3 +12,43 @@ end
 macro maybe_threaded(ex)
     esc(_maybe_threaded(ex))
 end
+
+function _init_backend()
+    quote
+        using Pkg
+        deps = Pkg.project().dependencies
+        const backend = JACC.JACCPreferences.backend
+        if backend == "cuda"
+            if !haskey(deps, "CUDA")
+                Pkg.add("CUDA")
+                @info "Added CUDA (be careful about committing Project.jl)"
+            end
+            using CUDA
+            @info "CUDA backend loaded"
+
+        elseif backend == "amdgpu"
+            if !haskey(deps, "AMDGPU")
+                Pkg.add(; name = "AMDGPU", version = "v0.8.6")
+                # Pkg.add("AMDGPU")
+                @info "Added AMDGPU (be careful about committing Project.jl)"
+            end
+            using AMDGPU
+            @info "AMDGPU backend loaded"
+
+        elseif backend == "oneapi"
+            if !haskey(deps, "oneAPI")
+                Pkg.add("oneAPI")
+                @info "Added oneAPI (be careful about committing Project.jl)"
+            end
+            using oneAPI
+            @info "oneAPI backend loaded"
+
+        elseif backend == "threads"
+            @info "Threads backend loaded"
+        end
+    end
+end
+
+macro init_backend()
+    return esc(_init_backend())
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,29 +1,5 @@
 import JACC
-
-using Pkg
-
-const backend = JACC.JACCPreferences.backend
-
-@static if backend == "cuda"
-    # Pkg.add(; name = "CUDA", version = "v5.1.1")
-    Pkg.add("CUDA")
-    @info "CUDA backend loaded"
-    using CUDA
-
-elseif backend == "amdgpu"
-    Pkg.add(; name = "AMDGPU", version = "v0.8.6")
-    # Pkg.add("AMDGPU")
-    @info "AMDGPU backend loaded"
-    using AMDGPU
-
-elseif backend == "oneapi"
-    Pkg.add("oneAPI")
-    @info "oneAPI backend loaded"
-    using oneAPI
-
-elseif backend == "threads"
-    @info "Threads backend loaded"
-end
+JACC.@init_backend
 
 using ReTest
 include("JACCTests.jl")


### PR DESCRIPTION
Addresses the other (first) half of #98.

`@init_backend` may be called by user code rather than, for example, `using CUDA` to preserve portability. This will add the required package (if necessary) and insert a `using` statement based on the selected backend (from JACCPreferences).