### PR TITLE
Parallel reduce with for loop instead of while loop and a fix for AMDGPU package install

### DIFF
--- a/ext/AMDGPUExt/multi.jl
+++ b/ext/AMDGPUExt/multi.jl
@@ -2,7 +2,7 @@ module Multi
 
 import Base: Callable
 using JACC, AMDGPU
-using JACCAMDGPU: AMDGPUBackend
+using AMDGPUExt: AMDGPUBackend
 
 function JACC.Multi.ndev(::AMDGPUBackend)
     return length(AMDGPU.devices())


### PR DESCRIPTION
Parallel reduce is creating an issue with recent LLVM/Julia code. 
It throws a LLVM instruction combine error during run. 

This error message indicates that LLVM’s optimizer is running into a bug when trying to combine instructions in our parallel_reduce kernel code. This is usually not an error in our logic but rather an artifact of how LLVM is optimizing our parallel_reduce code. The pattern of a while loop with dynamic shared memory can trigger this bug. This issue can be resolved by replacing the while loop with a for loop that computes the reduction in fixed steps.

This repository also have one more fix. JACC.jl Pkg installation is failing with AMDGPUExt as it is using JACCAMDGPU instead of AMDGPUExt. 

