### PR TITLE
Use -1 to signal default shmem_size

### DIFF
--- a/ext/AMDGPUExt/AMDGPUExt.jl
+++ b/ext/AMDGPUExt/AMDGPUExt.jl
@@ -45,7 +45,7 @@ function JACC.parallel_for(
     if spec.blocks == 0
         spec.blocks = cld(N, spec.threads)
     end
-    if spec.shmem_size == 0
+    if spec.shmem_size < 0
         spec.shmem_size = max_shmem_size()
     end
     kernel(
@@ -156,7 +156,7 @@ function JACC.parallel_for(
         spec.blocks = (cld(m, spec.threads[1]), cld(n, spec.threads[2]))
     end
 
-    if spec.shmem_size == 0
+    if spec.shmem_size < 0
         spec.shmem_size = max_shmem_size()
     end
 
@@ -199,7 +199,7 @@ function JACC.parallel_for(
         Nblocks = cld(N, spec.threads[3])
         spec.blocks = (Lblocks, Mblocks, Nblocks)
     end
-    if spec.shmem_size == 0
+    if spec.shmem_size < 0
         spec.shmem_size = max_shmem_size()
     end
     @roc groupsize=spec.threads gridsize=spec.blocks shmem=spec.shmem_size stream=spec.stream _parallel_for_amdgpu_LMN(

--- a/ext/CUDAExt/CUDAExt.jl
+++ b/ext/CUDAExt/CUDAExt.jl
@@ -52,7 +52,7 @@ function JACC.parallel_for(
     if spec.blocks == 0
         spec.blocks = cld(N, spec.threads)
     end
-    if spec.shmem_size == 0
+    if spec.shmem_size < 0
         spec.shmem_size = max_shmem_size()
     end
     kernel(kargs...; threads = spec.threads, blocks = spec.blocks,
@@ -165,7 +165,7 @@ function JACC.parallel_for(
         spec.blocks = (cld(m, spec.threads[1]), cld(n, spec.threads[2]))
     end
 
-    if spec.shmem_size == 0
+    if spec.shmem_size < 0
         spec.shmem_size = max_shmem_size()
     end
 
@@ -209,7 +209,7 @@ function JACC.parallel_for(
         Nblocks = cld(N, spec.threads[3])
         spec.blocks = (Lblocks, Mblocks, Nblocks)
     end
-    if spec.shmem_size == 0
+    if spec.shmem_size < 0
         spec.shmem_size = max_shmem_size()
     end
     @cuda threads=spec.threads blocks=spec.blocks shmem=spec.shmem_size stream=spec.stream _parallel_for_cuda_LMN(

--- a/src/JACC.jl
+++ b/src/JACC.jl
@@ -33,7 +33,7 @@ const Dims = Union{Integer, NTuple{2, Integer}, NTuple{3, Integer}}
     stream = default_stream(Backend)
     threads = 0
     blocks = 0
-    shmem_size::Int = 0
+    shmem_size::Int = -1
     sync::Bool = false
 end
 


### PR DESCRIPTION
This allows for `LaunchSpec.shmem_size = 0` to specify zero shmem.

Alternative to #268

Closes #271 