### PR TITLE
Refactored `ParallelReduce` outer constructors into JACC.reducer

### DIFF
--- a/ext/AMDGPUExt/async.jl
+++ b/ext/AMDGPUExt/async.jl
@@ -63,8 +63,8 @@ end
 function JACC.Async.parallel_reduce(::AMDGPUBackend, id::Integer,
         dims::JACC.IDims, op::Callable, f::Callable, x...; init)
     set_relative_device!(id)
-    reducer = JACC.ParallelReduce{AMDGPUBackend, typeof(init)}(;
-        range = dims, op = op, init = init, sync = false)
+    reducer = JACC.reducer(; backend = AMDGPUBackend(), range = dims, op = op,
+        init = init, sync = false)
     reducer(f, x...)
     ret = reducer.workspace.ret
     AMDGPU.device_id!(1)

--- a/ext/CUDAExt/async.jl
+++ b/ext/CUDAExt/async.jl
@@ -63,8 +63,8 @@ function JACC.Async.parallel_reduce(
         ::CUDABackend, id::Integer, dims::JACC.IDims,
         op::Callable, f::Callable, x...; init)
     set_relative_device!(id)
-    reducer = JACC.ParallelReduce{CUDABackend, typeof(init)}(;
-        range = dims, op = op, init = init, sync = false)
+    reducer = JACC.reducer(; backend = CUDABackend(), range = dims, op = op,
+        init = init, sync = false)
     reducer(f, x...)
     ret = reducer.workspace.ret
     CUDA.device!(0)

--- a/ext/oneAPIExt/async.jl
+++ b/ext/oneAPIExt/async.jl
@@ -62,8 +62,8 @@ end
 function JACC.Async.parallel_reduce(::oneAPIBackend, id::Integer,
         dims::JACC.IDims, op::Callable, f::Callable, x...; init)
     set_relative_device!(id)
-    reducer = JACC.ParallelReduce{oneAPIBackend, typeof(init)}(;
-        range = dims, op = op, init = init, sync = false)
+    reducer = JACC.reducer(; backend = oneAPIBackend(), range = dims, op = op,
+        init = init, sync = false)
     reducer(f, x...)
     ret = reducer.workspace.ret
     oneAPI.device!(1)

--- a/ext/oneAPIExt/multi.jl
+++ b/ext/oneAPIExt/multi.jl
@@ -420,7 +420,7 @@ function JACC.Multi.parallel_reduce(
     for i in 1:ndev
         oneAPI.device!(i)
         dev_id = i
-        reducer = JACC.ParallelReduce{oneAPIBackend, Float64}(;
+        reducer = JACC.reducer(; backend = oneAPIBackend(), type = Float64,
             range = N_multi, op = +, sync = false)
         reducer(f, process_param.((x), dev_id)...)
         rret[i] = reducer.workspace.ret
@@ -452,7 +452,7 @@ function JACC.Multi.parallel_reduce(
     for i in 1:ndev
         oneAPI.device!(i)
         dev_id = i
-        reducer = JACC.ParallelReduce{oneAPIBackend, Float64}(;
+        reducer = JACC.reducer(; backend = oneAPIBackend(), type = Float64,
             range = dims_multi, op = +, sync = false)
         reducer(f, process_param.((x), dev_id)...)
         rret[i] = reducer.workspace.ret

--- a/src/threads/threads.jl
+++ b/src/threads/threads.jl
@@ -136,8 +136,8 @@ end
 
 @inline function JACC.parallel_reduce(
         f, ::ThreadsBackend, N::Integer, x...; op, init)
-    reducer = JACC.ParallelReduce{ThreadsBackend, typeof(init)}(;
-        range = N, op = op, init = init)
+    reducer = JACC.reducer(
+        backend = ThreadsBackend(), range = N, op = op, init = init)
     reducer(f, x...)
     return JACC.get_result(reducer)
 end
@@ -191,8 +191,8 @@ end
 @inline function JACC.parallel_reduce(f, ::ThreadsBackend,
         (M, N)::NTuple{2, Integer}, x...; op, init)
     dims = (M, N)
-    reducer = JACC.ParallelReduce{ThreadsBackend, typeof(init)}(;
-        range = dims, op = op, init = init)
+    reducer = JACC.reducer(
+        backend = ThreadsBackend(), range = dims, op = op, init = init)
     reducer(f, x...)
     return JACC.get_result(reducer)
 end


### PR DESCRIPTION
This addresses the the method overwrite I introduced in rc1.