### PR TITLE
Update AMDGPU perf-test kernel

### DIFF
--- a/test/tests-performance/tests_amdgpu_perf.jl
+++ b/test/tests-performance/tests_amdgpu_perf.jl
@@ -10,10 +10,10 @@ using Test
     end
 
     function axpy_amdgpu(SIZE, alpha, x, y)
-        maxPossibleThreads = 512
+        maxPossibleThreads = AMDGPU.Device._max_group_size
         threads = min(SIZE, maxPossibleThreads)
         blocks = ceil(Int, SIZE / threads)
-        @roc groupsize=threads gridsize=threads * blocks axpy_amdgpu_kernel(
+        @roc groupsize=threads gridsize=blocks axpy_amdgpu_kernel(
             alpha, x, y)
     end
 


### PR DESCRIPTION
This PR uses AMDGPU API to query the max block size for the device.

The PR also corrects the grid size for usage with latest version of AMDGPU where grid represents the number of blocks and not the total number of threads across all blocks as before.