### PR TITLE
Add `JACC.transfer!`

### DIFF
--- a/docs/src/api_usage.md
+++ b/docs/src/api_usage.md
@@ -60,6 +60,7 @@ JACC.@init_backend
 - **`JACC.fill`**: create a new array on the device filled with a specified value.
 - **`JACC.to_device`**: transfer an existing Julia array from host to device.
 - **`JACC.to_host`**: transfer an existing JACC array from device to host.
+- **`JACC.transfer!`**: in-place version of `to_device` or `to_host`.
    
 Advanced memory:
 - **`JACC.Multi module`**: allows the programmability of multiple-GPU devices on a single node without the need of MPI. Please see the paper [Valero-Lara et al. IEEE eScience 2025](https://ieeexplore.ieee.org/document/11181490) 

--- a/src/array.jl
+++ b/src/array.jl
@@ -4,6 +4,25 @@ array_type() = array_type(default_backend())
 to_device(x::AbstractArray) = convert(array_type(), x)
 to_host(x::AbstractArray) = convert(Base.Array, x)
 
+"""
+    transfer!(dst::AbstractArray{T, N}, src::AbstractArray{T, N}) where {T, N} -> dst
+
+Transfer array `src` to array `dst`, discarding pre-existing elements in `dst`.
+
+Throw an `ArgumentError` if arrays do not have equal axes.
+
+!!! warning
+    Behavior can be unexpected when any mutated argument shares memory with any other argument.
+
+See also [`copyto!`](@ref).
+"""
+function transfer!(dst::AbstractArray{T, N}, src::AbstractArray{T, N}) where {T, N}
+    axes(dst) == axes(src) || throw(ArgumentError(
+    "arrays must have the same axes for `transfer!` (consider using `copyto!`)"))
+    copyto!(dst, src)
+    dst
+end
+
 array(x::AbstractArray) = to_device(x)
 
 array(::Type{T}, dims) where {T} = array_type(){T,length(dims)}(undef, dims)

--- a/src/array.jl
+++ b/src/array.jl
@@ -16,16 +16,51 @@ Throw an `ArgumentError` if arrays do not have equal axes.
 
 See also [`copyto!`](@ref).
 """
-function transfer!(dst::AbstractArray{T, N}, src::AbstractArray{T, N}) where {T, N}
+function transfer!(dst::AbstractArray{T, N}, src::AbstractArray{
+        T, N}) where {T, N}
     axes(dst) == axes(src) || throw(ArgumentError(
-    "arrays must have the same axes for `transfer!` (consider using `copyto!`)"))
-    copyto!(dst, src)
+        "arrays must have the same axes for `transfer!` (consider using `copyto!`)"))
+    _transfer!(dst, IndexStyle(dst), src, IndexStyle(src))
     dst
+end
+
+function _transfer!(dst::AbstractArray{T}, ::IndexCartesian,
+        src::AbstractArray{T}, ::IndexStyle) where {T}
+    _cartesian_transfer!(dst, src)
+end
+
+function _transfer!(dst::AbstractArray{T}, ::IndexStyle,
+        src::AbstractArray{T}, ::IndexCartesian) where {T}
+    _cartesian_transfer!(dst, src)
+end
+
+function _transfer!(dst::AbstractArray{T}, ::IndexCartesian,
+        src::AbstractArray{T}, ::IndexCartesian) where {T}
+    _cartesian_transfer!(dst, src)
+end
+
+function _transfer!(dst::AbstractArray{T}, ::IndexLinear,
+        src::AbstractArray{T}, ::IndexLinear) where {T}
+    _linear_transfer!(dst, src)
+end
+
+function _cartesian_transfer!(dst::AbstractArray{T}, src::AbstractArray{T}) where {T}
+    copyto!(parent(dst), CartesianIndices(parentindices(dst)),
+        parent(src), CartesianIndices(parentindices(src)))
+end
+
+_prep_for_linear_copy(a::AbstractArray{T}, p::AbstractArray{T}) where {T} = a
+function _prep_for_linear_copy(a::AbstractArray{T}, p::Base.Array{T}) where {T}
+    unsafe_wrap(Base.Array, pointer(a), length(a))
+end
+
+function _linear_transfer!(dst::AbstractArray{T}, src::AbstractArray{T}) where {T}
+    copyto!(_prep_for_linear_copy(dst, parent(dst)), _prep_for_linear_copy(src, parent(src)))
 end
 
 array(x::AbstractArray) = to_device(x)
 
-array(::Type{T}, dims) where {T} = array_type(){T,length(dims)}(undef, dims)
+array(::Type{T}, dims) where {T} = array_type(){T, length(dims)}(undef, dims)
 array(::Type{T}, dims...) where {T} = array(T, dims)
 array(dims) = array(default_float(), dims)
 array(dims...) = array(dims)

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -87,9 +87,21 @@ end
     h1 = rand(Float32, 10)
     h2 = zeros(Float32, 10)
     JACC.transfer!(view(d, 6:8), view(h1, 2:4))
-    @test [ones(Float32, 5); h1[2:4]; ones(Float32, 2);] == to_host(d)
+    @test [ones(Float32, 5); h1[2:4]; ones(Float32, 2);] == JACC.to_host(d)
     JACC.transfer!(view(h2, 6:8), view(d, 6:8))
     @test [zeros(Float32, 5); h1[2:4]; zeros(Float32, 2);] == h2
+
+    # 2D
+    md = JACC.zeros(Float32, 10, 10)
+    mh = rand(Float32, 10, 10)
+    JACC.transfer!(md, mh)
+    @test mh == JACC.to_host(md)
+    md = JACC.zeros(Float32, 10, 10)
+    JACC.transfer!(view(md, 6:8, 6:8), view(mh, 2:4, 2:4))
+    mh2 = zeros(Float32, 10, 10)
+    copyto!(view(mh2, 6:8, 6:8), view(mh, 2:4, 2:4))
+    @test mh2 == JACC.to_host(md)
+
 end
 
 @testset "VectorAddLambda" begin

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -61,6 +61,37 @@ end
     @test size(x) == (5, 5, 5)
 end
 
+@testset "transfer!" begin
+    N = 10
+    d = JACC.array(Float32, N)
+    h1 = rand(Float32, N)
+    h2 = zeros(Float32, N)
+    # transfer host to device
+    @test JACC.transfer!(d, h1) === d
+    @test h1 == JACC.to_host(d)
+
+    # transfer device to host
+    @test JACC.transfer!(h2, d) === h2
+    @test h1 == h2
+
+    # non equal axes will throw an argument error.
+    @test_throws ArgumentError JACC.transfer!(zeros(Float32, 3), JACC.ones(Float32, 2))
+    @test_throws ArgumentError JACC.transfer!(zeros(Float32, 3), JACC.ones(Float32, 4))
+
+    # mismatching element types or dim should throw a method error
+    @test_throws MethodError  JACC.transfer!(zeros(Int32, 3), JACC.ones(Float32, 3))
+    @test_throws MethodError  JACC.transfer!(zeros(Float32, 3, 1), JACC.ones(Float32, 3))
+
+    # transfer! with views should work as expected
+    d = JACC.ones(Float32, 10)
+    h1 = rand(Float32, 10)
+    h2 = zeros(Float32, 10)
+    JACC.transfer!(view(d, 6:8), view(h1, 2:4))
+    @test [ones(Float32, 5); h1[2:4]; ones(Float32, 2);] == to_host(d)
+    JACC.transfer!(view(h2, 6:8), view(d, 6:8))
+    @test [zeros(Float32, 5); h1[2:4]; zeros(Float32, 2);] == h2
+end
+
 @testset "VectorAddLambda" begin
     function f(i, a)
         @inbounds a[i] += 5.0


### PR DESCRIPTION
This PR adds a new function `transfer!` as an in-place version of `to_host` or `to_device`. Fixes #356 

Unlike `copy!` or `copyto!`, `transfer!` checks that the source and destination arrays have the same axes and element type.

The tests currently fail because `copyto!` doesn't work with views when using CUDA.jl. I think it is important to be able to handle basic contiguous views of host and device arrays, especially since the function has strict axes checks. But should this be fixed in JACC.jl, CUDA.jl, or somewhere else?

Also looking for feedback on the function name. I had originally thought of using `to_host!` and `to_device!`, but it turns out a single `transfer!` function can do both.