### PR TITLE
Use `Polyester.@batch` for basic parallel loops

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,6 +10,7 @@ authors = [
 [deps]
 Atomix = "a9b6321e-bd34-4604-b9c9-b65b8de01458"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+Polyester = "f517fe37-dbe3-4b94-8317-1923a5111588"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 
 [weakdeps]
@@ -30,6 +31,7 @@ Atomix = "1"
 CUDA = "5, 6"
 Metal = "1.9"
 Pkg = "1.11"
+Polyester = "0.7.19"
 Preferences = "1.4"
 julia = "1.11"
 oneAPI = "=2.4"

--- a/src/threads/threads.jl
+++ b/src/threads/threads.jl
@@ -1,5 +1,7 @@
 module ThreadsImpl
 
+import Polyester
+
 import JACC
 import JACC: LaunchSpec
 
@@ -12,7 +14,7 @@ function _maybe_threaded(ex)
         if Threads.nthreads() == 1
             $ex
         else
-            Threads.@threads :static $ex
+            Polyester.@batch $ex
         end
     end
 end
@@ -111,7 +113,7 @@ end
     nchunks = Threads.nthreads()
     chunks = collect(Base.Iterators.partition(1:N, cld(N, nchunks)))
     nchunks = length(chunks)
-    Threads.@threads :static for n in 1:nchunks
+    Polyester.@batch for n in 1:nchunks
         @inbounds begin
             tp = reducer.init
             for i in chunks[n]
@@ -164,7 +166,7 @@ end
     nchunks = Threads.nthreads()
     chunks = collect(Base.Iterators.partition(ids, cld(length(ids), nchunks)))
     nchunks = length(chunks)
-    Threads.@threads :static for n in 1:nchunks
+    Polyester.@batch for n in 1:nchunks
         @inbounds begin
             tp = reducer.init
             for ij in chunks[n]


### PR DESCRIPTION
I'm seeing significant improvements with our basic benchmarks.

Closes #362 

@boussuge , @williamfgc , @pedrovalerolara do any of you have a reason to make this optional for users? I'd prefer the firm change as I've done here.