### PR TITLE
Update Codecov CLI binary path in CI workflow

### DIFF
--- a/.github/workflows/ci-gpu-Apple.yaml
+++ b/.github/workflows/ci-gpu-Apple.yaml
@@ -91,7 +91,7 @@ jobs:
         if: steps.check.outputs.triggered == 'true'
         uses: codecov/codecov-action@v5
         with:
-          binary: /Users/wfg/Library/Python/3.13/bin/codecov-cli
+          binary: /Users/wfg/Library/Python/3.9/bin/codecov-cli
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: true


### PR DESCRIPTION
Direct to existing Python 3.9 interpreter