### PR TITLE
fix argument order of copyto!() in cg async code

### DIFF
--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1186,7 +1186,7 @@ if JACC.backend != "amdgpu" && JACC.backend != "metal"
         cond = 1.0
 
         while cond[1, 1] >= 1e-14
-            copyto!(r, r_old)
+            copyto!(r_old, r)
 
             JACC.Async.parallel_for(1, SIZE, matvecmul, a0, a1, a2, p, s1, SIZE)
 
@@ -1207,7 +1207,7 @@ if JACC.backend != "amdgpu" && JACC.backend != "metal"
             JACC.Async.synchronize()
             beta = JACC.to_host(beta0)[] / JACC.to_host(beta1)[]
 
-            copyto!(r, r_aux)
+            copyto!(r_aux, r)
 
             JACC.Async.parallel_for(1, SIZE, axpy, beta, r_aux, p)
             ccond = JACC.Async.parallel_reduce(2, SIZE, dot, r, r)


### PR DESCRIPTION
Fixes an issue where the arguments in copyto!(r, r_old) and copyto!(r, r_aux) are in the wrong order. 

Updates these functions calls to be copyto!(r_old, r) and copyto!(r_aux, r).