### PR TITLE
Fix duplicate argument in `axpy_threads`

### DIFF
--- a/test/benchmarks/backend/threads.jl
+++ b/test/benchmarks/backend/threads.jl
@@ -5,9 +5,9 @@ function axpy_threads(SIZE::Integer, alpha, x, y)
     end
 end
 
-function axpy_threads((SIZE, SIZE)::NTuple{2, Integer}, alpha, x, y)
-    Threads.@threads for j in 1:SIZE
-        for i in 1:SIZE
+function axpy_threads((M, N)::NTuple{2, Integer}, alpha, x, y)
+    Threads.@threads for j in 1:N
+        for i in 1:M
             axpy(i, j, alpha, x, y)
         end
     end


### PR DESCRIPTION
Julia currently doesn't check destructured arguments for duplicate names, but I'd like to make that an error like it is for normal arguments.  I'm assuming this is a typo (the first SIZE is ignored currently), but let me know if I misunderstood the intent.