### PR TITLE
Fix 2D parallel_for coalescing and remove per-reduce fill! (CUDA/AMDGPU)

### DIFF
--- a/ext/AMDGPUExt/AMDGPUExt.jl
+++ b/ext/AMDGPUExt/AMDGPUExt.jl
@@ -100,6 +100,27 @@ function (blkIter::BlockIndexerSwapped)()
 end
 # COV_EXCL_STOP
 
+# Coalescing-aware 2D block shape for a column-major (m rows x n cols) launch.
+# Consecutive workitems (workitemIdx().x, the wavefront direction) must walk the
+# stride-1 (row) dimension for global-memory access to coalesce. The aspect-ratio
+# heuristic gives good shapes for square/tall arrays, but starves x (down to 1
+# workitem) for wide arrays — so we floor x at a full warp whenever there are
+# enough rows, and otherwise use every available row.
+@inline function _block_shape_2d(maxthreads, m, n)
+    maxThreadsX = sqrt(maxthreads)
+    y_thr = clamp(floor(Int, (n / m) * maxThreadsX), 1, maxthreads)
+    x_thr = fld(maxthreads, y_thr)
+    if x_thr < 32 && m >= 32
+        x_thr = 32
+        y_thr = fld(maxthreads, x_thr)
+    elseif m < 32 && x_thr < m
+        x_thr = m
+        y_thr = max(1, fld(maxthreads, x_thr))
+    end
+    return (x_thr, y_thr)
+end
+
+# Generic launcher used for the swapped-axes fallback (uncoalesced, last resort).
 function _parallel_for(indexer::TI, f, (m, n), (M, N), x...) where {TI}
     kargs = _kernel_args(indexer, (M, N), f, x...)
     kernel, shmem_size = _kernel_maxshmem(_parallel_for_amdgpu_MN, kargs)
@@ -118,10 +139,21 @@ function JACC.parallel_for(
     dev = AMDGPU.device()
     props = AMDGPU.HIP.properties(dev)
     maxBlocks = (x = props.maxGridSize[1], y = props.maxGridSize[2])
-    if M < N && maxBlocks.x >= maxBlocks.y
+    # Prefer the coalesced (basic) mapping and only swap axes when it is
+    # *necessary* — i.e. when the basic grid would exceed the y-dimension limit.
+    # Swapping moves the large extent onto the x-axis (which has a far larger
+    # limit) but sacrifices memory coalescing, so it must be a last resort.
+    kargs = _kernel_args(BlockIndexerBasic(), (M, N), f, x...)
+    kernel, shmem_size = _kernel_maxshmem(_parallel_for_amdgpu_MN, kargs)
+    config = AMDGPU.launch_configuration(kernel; shmem = shmem_size)
+    x_thr, y_thr = _block_shape_2d(config.groupsize, M, N)
+    if cld(N, y_thr) > maxBlocks.y && maxBlocks.x >= maxBlocks.y
         _parallel_for(BlockIndexerSwapped(), f, (N, M), (M, N), x...)
     else
-        _parallel_for(BlockIndexerBasic(), f, (M, N), (M, N), x...)
+        blocks = (cld(M, x_thr), cld(N, y_thr))
+        kernel(kargs...; groupsize = (x_thr, y_thr), gridsize = blocks,
+            shmem = shmem_size)
+        AMDGPU.synchronize()
     end
 end
 
@@ -158,10 +190,37 @@ function JACC.parallel_for(
     dev = AMDGPU.device()
     props = AMDGPU.HIP.properties(dev)
     maxBlocks = (x = props.maxGridSize[1], y = props.maxGridSize[2])
-    if M < N && maxBlocks.x >= maxBlocks.y
-        _parallel_for(BlockIndexerSwapped(), f, spec, (N, M), (M, N), x...)
+    # Determine the y-threads the basic launch would use (from the user's block
+    # if given, otherwise the coalescing-aware default), then swap axes only if
+    # the basic grid would overflow the y-dimension limit.
+    if spec.threads == 0
+        kargs = _kernel_args(BlockIndexerBasic(), (M, N), f, x...)
+        kernel, shmem_size = _kernel_maxshmem(_parallel_for_amdgpu_MN, kargs)
+        if spec.shmem_size < 0
+            spec.shmem_size = shmem_size
+        end
+        config = AMDGPU.launch_configuration(kernel; shmem = spec.shmem_size)
+        x_thr, y_thr = _block_shape_2d(config.groupsize, M, N)
+        if cld(N, y_thr) > maxBlocks.y && maxBlocks.x >= maxBlocks.y
+            _parallel_for(BlockIndexerSwapped(), f, spec, (N, M), (M, N), x...)
+        else
+            spec.threads = (x_thr, y_thr)
+            if spec.blocks == 0
+                spec.blocks = (cld(M, x_thr), cld(N, y_thr))
+            end
+            kernel(kargs...; groupsize = spec.threads, gridsize = spec.blocks,
+                shmem = spec.shmem_size, stream = spec.stream)
+            if spec.sync
+                AMDGPU.synchronize(spec.stream)
+            end
+        end
     else
-        _parallel_for(BlockIndexerBasic(), f, spec, (M, N), (M, N), x...)
+        y_thr = spec.threads[2]
+        if cld(N, y_thr) > maxBlocks.y && maxBlocks.x >= maxBlocks.y
+            _parallel_for(BlockIndexerSwapped(), f, spec, (N, M), (M, N), x...)
+        else
+            _parallel_for(BlockIndexerBasic(), f, spec, (M, N), (M, N), x...)
+        end
     end
 end
 
@@ -224,13 +283,14 @@ function JACC.reduce_workspace(::AMDGPUBackend, tmp::AMDGPU.ROCArray{T},
     AMDGPUReduceWorkspace{T, JACC.Unmanaged}(tmp, init)
 end
 
+# Ensure the partial-results buffer is sized for this launch. `init` is seeded
+# directly inside the kernels (passed as an argument), so no `fill!` is needed
+# here — the reduce is a pure sequence of async kernel launches on the stream.
 @inline function _init!(
         wk::AMDGPUReduceWorkspace{T, JACC.Managed}, blocks, init) where {T}
     if length(wk.tmp) != prod(blocks)
         wk.tmp = AMDGPU.ROCArray{typeof(init)}(undef, blocks)
     end
-    fill!(wk.tmp, init)
-    fill!(wk.ret, init)
     return nothing
 end
 
@@ -247,10 +307,10 @@ function JACC._parallel_reduce!(reducer::JACC.ParallelReduce{AMDGPUBackend},
     op = reducer.op
     init = reducer.init
 
-    kargs1 = _kernel_args(N, op, wk.ret, f, x...)
+    kargs1 = _kernel_args(N, op, wk.ret, init, f, x...)
     kernel1, threads1 = _kernel_maxthreads(_parallel_reduce_amdgpu, kargs1)
 
-    kargs2 = _kernel_args(1, op, wk.ret, wk.ret)
+    kargs2 = _kernel_args(1, op, wk.ret, init, wk.ret)
     kernel2, threads2 = _kernel_maxthreads(_reduce_kernel_amdgpu, kargs2)
 
     threads = min(threads1, threads2, 512)
@@ -259,11 +319,11 @@ function JACC._parallel_reduce!(reducer::JACC.ParallelReduce{AMDGPUBackend},
 
     _init!(wk, blocks, init)
 
-    kargs1 = _kernel_args(N, op, wk.tmp, f, x...)
+    kargs1 = _kernel_args(N, op, wk.tmp, init, f, x...)
     kernel1(kargs1...; groupsize = threads, gridsize = blocks,
         shmem = shmem_size, stream = reducer.stream)
 
-    kargs2 = _kernel_args(blocks, op, wk.tmp, wk.ret)
+    kargs2 = _kernel_args(blocks, op, wk.tmp, init, wk.ret)
     kernel2(kargs2...; groupsize = threads, gridsize = 1,
         shmem = shmem_size, stream = reducer.stream)
 
@@ -277,11 +337,11 @@ end
 function JACC.parallel_reduce(f, ::AMDGPUBackend, N::Integer, x...; op, init)
     ret_inst = AMDGPU.ROCArray{typeof(init)}(undef, 0)
 
-    kargs1 = _kernel_args(N, op, ret_inst, f, x...)
+    kargs1 = _kernel_args(N, op, ret_inst, init, f, x...)
     kernel1, threads1 = _kernel_maxthreads(_parallel_reduce_amdgpu, kargs1)
 
     rret = AMDGPU.ROCArray([init])
-    kargs2 = _kernel_args(1, op, ret_inst, rret)
+    kargs2 = _kernel_args(1, op, ret_inst, init, rret)
     kernel2, threads2 = _kernel_maxthreads(_reduce_kernel_amdgpu, kargs2)
 
     threads = min(threads1, threads2, 512)
@@ -289,12 +349,13 @@ function JACC.parallel_reduce(f, ::AMDGPUBackend, N::Integer, x...; op, init)
 
     shmem_size = threads * sizeof(init)
 
-    ret = fill!(AMDGPU.ROCArray{typeof(init)}(undef, blocks), init)
-    kargs1 = _kernel_args(N, op, ret, f, x...)
+    # no fill! — `init` is seeded inside the kernels; every block writes its slot
+    ret = AMDGPU.ROCArray{typeof(init)}(undef, blocks)
+    kargs1 = _kernel_args(N, op, ret, init, f, x...)
     kernel1(
         kargs1...; groupsize = threads, gridsize = blocks, shmem = shmem_size)
 
-    kargs2 = _kernel_args(blocks, op, ret, rret)
+    kargs2 = _kernel_args(blocks, op, ret, init, rret)
     kernel2(kargs2...; groupsize = threads, gridsize = 1, shmem = shmem_size)
     AMDGPU.synchronize()
 
@@ -317,12 +378,12 @@ function JACC._parallel_reduce!(reducer::JACC.ParallelReduce{AMDGPUBackend},
     wk = reducer.workspace
     _init!(wk, blocks, init)
 
-    kargs1 = _kernel_args((M, N), op, wk.tmp, f, x...)
+    kargs1 = _kernel_args((M, N), op, wk.tmp, init, f, x...)
     kernel1 = _make_kernel(_parallel_reduce_amdgpu_MN, kargs1)
     kernel1(kargs1...; groupsize = threads, gridsize = blocks,
         shmem = shmem_size, stream = reducer.stream)
 
-    kargs2 = _kernel_args(blocks, op, wk.tmp, wk.ret)
+    kargs2 = _kernel_args(blocks, op, wk.tmp, init, wk.ret)
     kernel2 = _make_kernel(_reduce_kernel_amdgpu_MN, kargs2)
     kernel2(kargs2...; groupsize = threads, gridsize = (1, 1),
         shmem = shmem_size, stream = reducer.stream)
@@ -344,14 +405,15 @@ function JACC.parallel_reduce(f, ::AMDGPUBackend, (M, N)::NTuple{2, Integer},
     Nblocks = cld(N, Nthreads)
     blocks = (Mblocks, Nblocks)
     shmem_size = 16 * 16 * sizeof(init)
-    ret = fill!(AMDGPU.ROCArray{typeof(init)}(undef, blocks), init)
+    # no fill! — `init` is seeded inside the kernels; every block writes its slot
+    ret = AMDGPU.ROCArray{typeof(init)}(undef, blocks)
     rret = AMDGPU.ROCArray([init])
 
-    kargs1 = _kernel_args((M, N), op, ret, f, x...)
+    kargs1 = _kernel_args((M, N), op, ret, init, f, x...)
     kernel1 = _make_kernel(_parallel_reduce_amdgpu_MN, kargs1)
     kernel1(kargs1...; groupsize = threads, gridsize = blocks, shmem = shmem_size)
 
-    kargs2 = _kernel_args(blocks, op, ret, rret)
+    kargs2 = _kernel_args(blocks, op, ret, init, rret)
     kernel2 = _make_kernel(_reduce_kernel_amdgpu_MN, kargs2)
     kernel2(kargs2...; groupsize = threads, gridsize = (1, 1), shmem = shmem_size)
 
@@ -394,12 +456,12 @@ end
     return nothing
 end
 
-@inline function _parallel_reduce_amdgpu(N, op, ret, f, x...)
+@inline function _parallel_reduce_amdgpu(N, op, ret, init, f, x...)
     shmem_length = workgroupDim().x
     shared_mem = @ROCDynamicLocalArray(eltype(ret), shmem_length, false)
     i = (workgroupIdx().x - 1) * workgroupDim().x + workitemIdx().x
     ti = workitemIdx().x
-    @inbounds shared_mem[ti] = ret[workgroupIdx().x]
+    @inbounds shared_mem[ti] = init
 
     if i <= N
         tmp = @inline f(i, x...)
@@ -421,12 +483,12 @@ end
     return nothing
 end
 
-function _reduce_kernel_amdgpu(N, op, red, ret)
+function _reduce_kernel_amdgpu(N, op, red, init, ret)
     shmem_length = workgroupDim().x
     shared_mem = @ROCDynamicLocalArray(eltype(ret), shmem_length, false)
     i = workitemIdx().x
     ii = i
-    @inbounds tmp = ret[1]
+    tmp = init
     for ii in i:shmem_length:N
         tmp = op(tmp, @inbounds red[ii])
     end
@@ -447,7 +509,7 @@ function _reduce_kernel_amdgpu(N, op, red, ret)
     return nothing
 end
 
-function _parallel_reduce_amdgpu_MN((M, N), op, ret, f, x...)
+function _parallel_reduce_amdgpu_MN((M, N), op, ret, init, f, x...)
     shared_mem = @ROCDynamicLocalArray(eltype(ret), (16, 16), false)
     i = (workgroupIdx().x - 1) * workgroupDim().x + workitemIdx().x
     j = (workgroupIdx().y - 1) * workgroupDim().y + workitemIdx().y
@@ -456,7 +518,7 @@ function _parallel_reduce_amdgpu_MN((M, N), op, ret, f, x...)
     bi = workgroupIdx().x
     bj = workgroupIdx().y
 
-    @inbounds shared_mem[ti, tj] = ret[bi, bj]
+    @inbounds shared_mem[ti, tj] = init
 
     if (i <= M && j <= N)
         tmp = @inline f(i, j, x...)
@@ -481,12 +543,12 @@ function _parallel_reduce_amdgpu_MN((M, N), op, ret, f, x...)
     return nothing
 end
 
-function _reduce_kernel_amdgpu_MN((M, N), op, red, ret)
+function _reduce_kernel_amdgpu_MN((M, N), op, red, init, ret)
     shared_mem = @ROCDynamicLocalArray(eltype(ret), (16, 16), false)
     i = workitemIdx().x
     j = workitemIdx().y
 
-    @inbounds tmp = ret[1]
+    tmp = init
     for ci in CartesianIndices((i:16:M, j:16:N))
         tmp = op(tmp, @inbounds red[ci])
     end

--- a/ext/CUDAExt/CUDAExt.jl
+++ b/ext/CUDAExt/CUDAExt.jl
@@ -95,6 +95,27 @@ function (blkIter::BlockIndexerSwapped)()
 end
 # COV_EXCL_STOP
 
+# Coalescing-aware 2D block shape for a column-major (m rows x n cols) launch.
+# Consecutive threads (threadIdx().x, the warp direction) must walk the stride-1
+# (row) dimension for global-memory access to coalesce. The aspect-ratio
+# heuristic gives good shapes for square/tall arrays, but starves x (down to 1
+# thread) for wide arrays — so we floor x at a full warp whenever there are
+# enough rows, and otherwise use every available row.
+@inline function _block_shape_2d(maxthreads, m, n)
+    maxThreadsX = sqrt(maxthreads)
+    y_thr = clamp(floor(Int, (n / m) * maxThreadsX), 1, maxthreads)
+    x_thr = fld(maxthreads, y_thr)
+    if x_thr < 32 && m >= 32
+        x_thr = 32
+        y_thr = fld(maxthreads, x_thr)
+    elseif m < 32 && x_thr < m
+        x_thr = m
+        y_thr = max(1, fld(maxthreads, x_thr))
+    end
+    return (x_thr, y_thr)
+end
+
+# Generic launcher used for the swapped-axes fallback (uncoalesced, last resort).
 function _parallel_for(indexer::TI, f, (m, n), (M, N), x...) where {TI}
     kargs = _kernel_args(indexer, (M, N), f, x...)
     kernel, shmem_size = _kernel_maxshmem(_parallel_for_cuda_MN, kargs)
@@ -114,10 +135,21 @@ function JACC.parallel_for(f, ::CUDABackend, (M, N)::NTuple{2, Integer}, x...)
         x = attribute(dev, CUDA.DEVICE_ATTRIBUTE_MAX_GRID_DIM_X),
         y = attribute(dev, CUDA.DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y)
     )
-    if M < N && maxBlocks.x >= maxBlocks.y
+    # Prefer the coalesced (basic) mapping and only swap axes when it is
+    # *necessary* — i.e. when the basic grid would exceed the y-dimension limit.
+    # Swapping moves the large extent onto the x-axis (which has a far larger
+    # limit) but sacrifices memory coalescing, so it must be a last resort.
+    kargs = _kernel_args(BlockIndexerBasic(), (M, N), f, x...)
+    kernel, shmem_size = _kernel_maxshmem(_parallel_for_cuda_MN, kargs)
+    config = CUDA.launch_configuration(kernel.fun; shmem = shmem_size)
+    x_thr, y_thr = _block_shape_2d(config.threads, M, N)
+    if cld(N, y_thr) > maxBlocks.y && maxBlocks.x >= maxBlocks.y
         _parallel_for(BlockIndexerSwapped(), f, (N, M), (M, N), x...)
     else
-        _parallel_for(BlockIndexerBasic(), f, (M, N), (M, N), x...)
+        blocks = (cld(M, x_thr), cld(N, y_thr))
+        kernel(kargs...; threads = (x_thr, y_thr), blocks = blocks,
+            shmem = shmem_size)
+        CUDA.synchronize()
     end
 end
 
@@ -156,10 +188,37 @@ function JACC.parallel_for(
         x = attribute(dev, CUDA.DEVICE_ATTRIBUTE_MAX_GRID_DIM_X),
         y = attribute(dev, CUDA.DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y)
     )
-    if M < N && maxBlocks.x >= maxBlocks.y
-        _parallel_for(BlockIndexerSwapped(), f, spec, (N, M), (M, N), x...)
+    # Determine the y-threads the basic launch would use (from the user's block
+    # if given, otherwise the coalescing-aware default), then swap axes only if
+    # the basic grid would overflow the y-dimension limit.
+    if spec.threads == 0
+        kargs = _kernel_args(BlockIndexerBasic(), (M, N), f, x...)
+        kernel, shmem_size = _kernel_maxshmem(_parallel_for_cuda_MN, kargs)
+        if spec.shmem_size < 0
+            spec.shmem_size = shmem_size
+        end
+        config = CUDA.launch_configuration(kernel.fun; shmem = spec.shmem_size)
+        x_thr, y_thr = _block_shape_2d(config.threads, M, N)
+        if cld(N, y_thr) > maxBlocks.y && maxBlocks.x >= maxBlocks.y
+            _parallel_for(BlockIndexerSwapped(), f, spec, (N, M), (M, N), x...)
+        else
+            spec.threads = (x_thr, y_thr)
+            if spec.blocks == 0
+                spec.blocks = (cld(M, x_thr), cld(N, y_thr))
+            end
+            kernel(kargs...; threads = spec.threads, blocks = spec.blocks,
+                shmem = spec.shmem_size, stream = spec.stream)
+            if spec.sync
+                CUDA.synchronize(spec.stream)
+            end
+        end
     else
-        _parallel_for(BlockIndexerBasic(), f, spec, (M, N), (M, N), x...)
+        y_thr = spec.threads[2]
+        if cld(N, y_thr) > maxBlocks.y && maxBlocks.x >= maxBlocks.y
+            _parallel_for(BlockIndexerSwapped(), f, spec, (N, M), (M, N), x...)
+        else
+            _parallel_for(BlockIndexerBasic(), f, spec, (M, N), (M, N), x...)
+        end
     end
 end
 
@@ -220,13 +279,14 @@ function JACC.reduce_workspace(::CUDABackend, tmp::CUDA.CuArray{T},
     CUDAReduceWorkspace{T, JACC.Unmanaged}(tmp, init)
 end
 
+# Ensure the partial-results buffer is sized for this launch. `init` is seeded
+# directly inside the kernels (passed as an argument), so no `fill!` is needed
+# here — the reduce is a pure sequence of async kernel launches on the stream.
 @inline function _init!(
         wk::CUDAReduceWorkspace{T, JACC.Managed}, blocks, init) where {T}
     if length(wk.tmp) != prod(blocks)
         wk.tmp = CUDA.CuArray{typeof(init)}(undef, blocks)
     end
-    fill!(wk.tmp, init)
-    fill!(wk.ret, init)
     return nothing
 end
 
@@ -243,10 +303,10 @@ function JACC._parallel_reduce!(reducer::JACC.ParallelReduce{CUDABackend},
     op = reducer.op
     init = reducer.init
 
-    kargs_1 = _kernel_args(N, op, wk.ret, f, x...)
+    kargs_1 = _kernel_args(N, op, wk.ret, init, f, x...)
     kernel_1, maxThreads_1 = _kernel_maxthreads(_parallel_reduce_cuda, kargs_1)
 
-    kargs_2 = _kernel_args(1, op, wk.ret, wk.ret)
+    kargs_2 = _kernel_args(1, op, wk.ret, init, wk.ret)
     kernel_2, maxThreads_2 = _kernel_maxthreads(_reduce_kernel_cuda, kargs_2)
 
     threads = min(maxThreads_1, maxThreads_2, 512)
@@ -255,11 +315,11 @@ function JACC._parallel_reduce!(reducer::JACC.ParallelReduce{CUDABackend},
 
     _init!(wk, blocks, init)
 
-    kargs = _kernel_args(N, op, wk.tmp, f, x...)
+    kargs = _kernel_args(N, op, wk.tmp, init, f, x...)
     kernel_1(kargs...; threads = threads, blocks = blocks,
         shmem = shmem_size, stream = reducer.stream)
 
-    kargs = _kernel_args(blocks, op, wk.tmp, wk.ret)
+    kargs = _kernel_args(blocks, op, wk.tmp, init, wk.ret)
     kernel_2(kargs...; threads = threads, blocks = 1,
         shmem = shmem_size, stream = reducer.stream)
 
@@ -273,11 +333,11 @@ end
 function JACC.parallel_reduce(f, ::CUDABackend, N::Integer, x...; op, init)
     ret_inst = CUDA.CuArray{typeof(init)}(undef, 0)
 
-    kargs_1 = _kernel_args(N, op, ret_inst, f, x...)
+    kargs_1 = _kernel_args(N, op, ret_inst, init, f, x...)
     kernel_1, maxThreads_1 = _kernel_maxthreads(_parallel_reduce_cuda, kargs_1)
 
     rret = CUDA.CuArray([init])
-    kargs_2 = _kernel_args(1, op, ret_inst, rret)
+    kargs_2 = _kernel_args(1, op, ret_inst, init, rret)
     kernel_2, maxThreads_2 = _kernel_maxthreads(_reduce_kernel_cuda, kargs_2)
 
     threads = min(maxThreads_1, maxThreads_2, 512)
@@ -285,11 +345,12 @@ function JACC.parallel_reduce(f, ::CUDABackend, N::Integer, x...; op, init)
 
     shmem_size = threads * sizeof(init)
 
-    ret = fill!(CUDA.CuArray{typeof(init)}(undef, blocks), init)
-    kargs = _kernel_args(N, op, ret, f, x...)
+    # no fill! — `init` is seeded inside the kernels; every block writes its slot
+    ret = CUDA.CuArray{typeof(init)}(undef, blocks)
+    kargs = _kernel_args(N, op, ret, init, f, x...)
     kernel_1(kargs...; threads = threads, blocks = blocks, shmem = shmem_size)
 
-    kargs = _kernel_args(blocks, op, ret, rret)
+    kargs = _kernel_args(blocks, op, ret, init, rret)
     kernel_2(kargs...; threads = threads, blocks = 1, shmem = shmem_size)
 
     CUDA.synchronize()
@@ -313,12 +374,12 @@ function JACC._parallel_reduce!(reducer::JACC.ParallelReduce{CUDABackend},
     wk = reducer.workspace
     _init!(wk, blocks, init)
 
-    kargs1 = _kernel_args((M, N), op, wk.tmp, f, x...)
+    kargs1 = _kernel_args((M, N), op, wk.tmp, init, f, x...)
     kernel1 = _make_kernel(_parallel_reduce_cuda_MN, kargs1)
     kernel1(kargs1...; threads = threads, blocks = blocks, shmem = shmem_size,
         stream = reducer.stream)
 
-    kargs2 = _kernel_args(blocks, op, wk.tmp, wk.ret)
+    kargs2 = _kernel_args(blocks, op, wk.tmp, init, wk.ret)
     kernel2 = _make_kernel(_reduce_kernel_cuda_MN, kargs2)
     kernel2(kargs2...; threads = threads, blocks = (1, 1), shmem = shmem_size,
         stream = reducer.stream)
@@ -340,14 +401,15 @@ function JACC.parallel_reduce(
     Nblocks = cld(N, Nthreads)
     blocks = (Mblocks, Nblocks)
     shmem_size = 16 * 16 * sizeof(init)
-    ret = fill!(CUDA.CuArray{typeof(init)}(undef, (Mblocks, Nblocks)), init)
+    # no fill! — `init` is seeded inside the kernels; every block writes its slot
+    ret = CUDA.CuArray{typeof(init)}(undef, (Mblocks, Nblocks))
     rret = CUDA.CuArray([init])
 
-    kargs1 = _kernel_args((M, N), op, ret, f, x...)
+    kargs1 = _kernel_args((M, N), op, ret, init, f, x...)
     kernel1 = _make_kernel(_parallel_reduce_cuda_MN, kargs1)
     kernel1(kargs1...; threads = threads, blocks = blocks, shmem = shmem_size)
 
-    kargs2 = _kernel_args((Mblocks, Nblocks), op, ret, rret)
+    kargs2 = _kernel_args((Mblocks, Nblocks), op, ret, init, rret)
     kernel2 = _make_kernel(_reduce_kernel_cuda_MN, kargs2)
     kernel2(kargs2...; threads = threads, blocks = (1, 1), shmem = shmem_size)
 
@@ -389,12 +451,12 @@ end
     return nothing
 end
 
-function _parallel_reduce_cuda(N, op, ret, f, x...)
+function _parallel_reduce_cuda(N, op, ret, init, f, x...)
     shmem_length = blockDim().x
     shared_mem = CuDynamicSharedArray(eltype(ret), shmem_length)
     i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
     ti = threadIdx().x
-    @inbounds shared_mem[ti] = ret[blockIdx().x]
+    @inbounds shared_mem[ti] = init
 
     if i <= N
         tmp = @inline f(i, x...)
@@ -416,12 +478,12 @@ function _parallel_reduce_cuda(N, op, ret, f, x...)
     return nothing
 end
 
-function _reduce_kernel_cuda(N, op, red, ret)
+function _reduce_kernel_cuda(N, op, red, init, ret)
     shmem_length = blockDim().x
     shared_mem = CuDynamicSharedArray(eltype(ret), shmem_length)
     i = threadIdx().x
     ii = i
-    @inbounds tmp = ret[1]
+    tmp = init
     for ii in i:shmem_length:N
         tmp = op(tmp, @inbounds red[ii])
     end
@@ -442,7 +504,7 @@ function _reduce_kernel_cuda(N, op, red, ret)
     return nothing
 end
 
-function _parallel_reduce_cuda_MN((M, N), op, ret, f, x...)
+function _parallel_reduce_cuda_MN((M, N), op, ret, init, f, x...)
     shared_mem = CuDynamicSharedArray(eltype(ret), (16, 16))
     i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
     j = (blockIdx().y - 1) * blockDim().y + threadIdx().y
@@ -451,7 +513,7 @@ function _parallel_reduce_cuda_MN((M, N), op, ret, f, x...)
     bi = blockIdx().x
     bj = blockIdx().y
 
-    @inbounds shared_mem[ti, tj] = ret[bi, bj]
+    @inbounds shared_mem[ti, tj] = init
 
     if (i <= M && j <= N)
         tmp = @inline f(i, j, x...)
@@ -476,12 +538,12 @@ function _parallel_reduce_cuda_MN((M, N), op, ret, f, x...)
     return nothing
 end
 
-function _reduce_kernel_cuda_MN((M, N), op, red, ret)
+function _reduce_kernel_cuda_MN((M, N), op, red, init, ret)
     shared_mem = CuDynamicSharedArray(eltype(ret), (16, 16))
     i = threadIdx().x
     j = threadIdx().y
 
-    @inbounds tmp = ret[1]
+    tmp = init
     for ci in CartesianIndices((i:16:M, j:16:N))
         tmp = op(tmp, @inbounds red[ci])
     end

--- a/ext/oneAPIExt/oneAPIExt.jl
+++ b/ext/oneAPIExt/oneAPIExt.jl
@@ -105,7 +105,7 @@ function _parallel_for(indexer::TI, f, spec::LaunchSpec{oneAPIBackend}, (m, n),
     end
 
     if spec.blocks == 0
-        spec.blocks = (cld(M, spec.threads[1]), cld(N, spec.threads[2]))
+        spec.blocks = (cld(m, spec.threads[1]), cld(n, spec.threads[2]))
     end
     kernel(
         indexer, (M, N), f, x...; items = spec.threads, groups = spec.blocks,

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1261,3 +1261,42 @@ if JACC.backend != "metal" && JACC.backend != "oneapi"
         @test all(0 .<= x_host .<= 1)
     end
 end
+
+# Regression tests for 2D `parallel_for`/`parallel_reduce` on NON-SQUARE arrays.
+#
+# On GPU backends, 2D kernels map one array dimension to the grid x-axis and the
+# other to the y-axis. When `M < N`, the axes are swapped so the larger extent
+# lands on the x-axis (whose grid-dimension limit is far larger than the y-axis).
+# All existing 2D tests use square `(N, N)` matrices, which never exercise that
+# swap, so bugs in the swapped index mapping / launch configuration are invisible.
+# These cases use both wide (`M < N`) and tall (`M > N`) shapes across a range of
+# aspect ratios and verify that every cell is covered exactly.
+@testset "parallel_for non-square 2D" begin
+    nonsquare_dims = [(2, 5), (5, 2), (7, 13), (13, 7),
+        (3, 257), (257, 3), (128, 1024), (1024, 128)]
+    write2d(i, j, A) = (@inbounds A[i, j] = (j - 1) * size(A, 1) + i; nothing)
+    for (M, N) in nonsquare_dims
+        exp = FloatType[(j - 1) * M + i for i in 1:M, j in 1:N]
+
+        # auto-configured launch
+        A = JACC.zeros(FloatType, M, N)
+        JACC.parallel_for((M, N), write2d, A)
+        @test JACC.to_host(A) == exp
+
+        # explicit thread block: the swap (when needed) must still cover every cell
+        B = JACC.zeros(FloatType, M, N)
+        JACC.parallel_for(JACC.launch_spec(; threads = (16, 16)), (M, N), write2d, B)
+        @test JACC.to_host(B) == exp
+    end
+end
+
+@testset "parallel_reduce non-square 2D" begin
+    nonsquare_dims = [(2, 5), (5, 2), (7, 13), (13, 7),
+        (3, 257), (257, 3), (128, 1024), (1024, 128)]
+    elem2d(i, j, A) = (@inbounds A[i, j])
+    for (M, N) in nonsquare_dims
+        A = JACC.ones(FloatType, M, N)
+        s = JACC.parallel_reduce((M, N), elem2d, A; op = +, init = zero(FloatType))
+        @test s == FloatType(M * N)
+    end
+end


### PR DESCRIPTION
## What

Two GPU-backend changes to `ext/CUDAExt/CUDAExt.jl` and `ext/AMDGPUExt/AMDGPUExt.jl`:

1. **2D `parallel_for` coalescing** — swap grid axes only when necessary, and keep a
   warp on the stride-1 dimension.
2. **Reduction `init` seeding** — pass `init` as a kernel argument instead of
   pre-filling buffers with `fill!`.

## Why

The `M < N` swap was a launchability workaround (the y-grid limit is 65535 vs. 2³¹
for x), but it fired for every wide array — including the vast majority that fit the
coalesced path — turning a bandwidth-bound kernel into a strided one. The `fill!`s
are extra kernel launches on the reduce critical path that only existed to place an
identity value the kernel can hold itself.

---

## Issue 1 — 2D `parallel_for` loses coalescing on wide arrays

A 2D launch maps one array dimension to the grid **x**-axis and the other to **y**.
`y` is limited to 65535 blocks; `x` to 2³¹. To launch a wide array (`M < N`) whose
`N` would overflow `grid.y`, the backend swaps axes so `N` lands on `x`.

The two index mappings differ in *which* array element each warp touches. Arrays are
column-major (`i` is stride-1):

```julia
# BlockIndexerBasic:   threadIdx().x -> i  (stride 1)  => a warp reads A[i:i+31, j]   → 1 cache line   ✅
# BlockIndexerSwapped: threadIdx().x -> j  (stride M)  => a warp reads A[i, j:j+31]   → 32 cache lines ❌
```

### Before (the bug)

The swap fired for **every** `M < N` array, even the majority whose basic grid fits
under the `y` limit — so a coalesced kernel was needlessly turned into a strided one:

```julia
# ext/CUDAExt/CUDAExt.jl (old)
if M < N && maxBlocks.x >= maxBlocks.y            # blanket rule
    _parallel_for(BlockIndexerSwapped(), f, (N, M), (M, N), x...)   # uncoalesced
else
    _parallel_for(BlockIndexerBasic(), f, (M, N), (M, N), x...)
end
```

Worse, the block-shape heuristic then starved the `x` (coalesced) dimension for wide
arrays, collapsing the block to `(1, threads)`:

```julia
y_thr = clamp(floor(Int, (n / m) * maxThreadsX), 1, config.threads)  # ~threads when n≫m
x_thr = fld(config.threads, y_thr)                                   # -> 1  (no warp on x)
```

### After (the fix)

Swap **only when the coalesced grid would actually overflow `grid.y`**, and shape the
block so a full warp walks the stride-1 dimension:

```julia
# ext/CUDAExt/CUDAExt.jl (new)
kargs = _kernel_args(BlockIndexerBasic(), (M, N), f, x...)
kernel, shmem = _kernel_maxshmem(_parallel_for_cuda_MN, kargs)
config = CUDA.launch_configuration(kernel.fun; shmem)
x_thr, y_thr = _block_shape_2d(config.threads, M, N)

if cld(N, y_thr) > maxBlocks.y && maxBlocks.x >= maxBlocks.y   # swap only if unavoidable
    _parallel_for(BlockIndexerSwapped(), f, (N, M), (M, N), x...)
else                                                          # coalesced fast path
    kernel(kargs...; threads = (x_thr, y_thr),
        blocks = (cld(M, x_thr), cld(N, y_thr)), shmem = shmem)
    CUDA.synchronize()
end
```

```julia
# keep a warp on the stride-1 (row) dimension; heuristic still handles square/tall
@inline function _block_shape_2d(maxthreads, m, n)
    maxThreadsX = sqrt(maxthreads)
    y_thr = clamp(floor(Int, (n / m) * maxThreadsX), 1, maxthreads)
    x_thr = fld(maxthreads, y_thr)
    if x_thr < 32 && m >= 32
        x_thr = 32; y_thr = fld(maxthreads, x_thr)
    elseif m < 32 && x_thr < m
        x_thr = m;  y_thr = max(1, fld(maxthreads, x_thr))
    end
    return (x_thr, y_thr)
end
```

### Reproduce (NVIDIA A100)

```julia
import JACC
JACC.@init_backend           # backend = "cuda"
using CUDA
scale2(i, j, A, B) = (@inbounds B[i, j] = 2f0 * A[i, j]; nothing)

function bw(M, N; iters = 100)
    A = CUDA.rand(Float32, M, N); B = CUDA.zeros(Float32, M, N)
    JACC.parallel_for((M, N), scale2, A, B); CUDA.synchronize()          # warmup
    t = CUDA.@elapsed (for _ in 1:iters; JACC.parallel_for((M, N), scale2, A, B); end;
                       CUDA.synchronize())
    2 * M * N * sizeof(Float32) / (t / iters) / 1e9                      # GB/s
end

bw(256, 262144)   # wide  — before: ~41 GB/s      after: ~770 GB/s
bw(262144, 256)   # tall  — ~770 GB/s (unchanged; reference for the coalesced path)
```

---

## Issue 2 — reductions do a synchronous `fill!` between kernel launches

The op-identity for out-of-range threads was placed by pre-filling the partial-results
buffer with `fill!` — two extra launches sitting between the reduction kernels, and the
`Unmanaged` workspace relied on the caller having pre-filled the buffers.

### Before

```julia
# host
_init!(wk, blocks, init)                       # fill!(wk.tmp, init); fill!(wk.ret, init)
kernel_1(N, op, wk.tmp, f, x...)
kernel_2(blocks, op, wk.tmp, wk.ret)
# launch sequence:  memset → memset → reduce_1 → reduce_2

# kernel
@inbounds shared_mem[ti] = ret[blockIdx().x]   # identity read back from the filled buffer
...
@inbounds tmp = ret[1]
```

### After

```julia
# host — `init` passed as an argument; _init! only sizes the buffer now
_init!(wk, blocks, init)
kernel_1(N, op, wk.tmp, init, f, x...)
kernel_2(blocks, op, wk.tmp, init, wk.ret)
# launch sequence:  reduce_1 → reduce_2   (pure async, no fill in between)

# kernel
@inbounds shared_mem[ti] = init                # identity seeded directly
...
tmp = init
```

### Reproduce (NVIDIA A100)

```julia
id(i, x) = (@inbounds x[i])
function us(N; iters = 500)              # microseconds per reduce
    r = JACC.reducer(Float64, N, +); x = JACC.ones(Float64, N)
    r(id, x); CUDA.synchronize()
    t = CUDA.@elapsed (for _ in 1:iters; r(id, x); end; CUDA.synchronize())
    t / iters * 1e6
end
us(1000)     # before: ~44.5 us   after: ~30.8 us   (two memset launches removed)
us(10^7)     # ~unchanged (bandwidth-bound)
```

---

## Performance (NVIDIA A100)

- Wide 2D `parallel_for`: **~5–19× faster** — e.g. 256×262144 went 41 → ~770 GB/s,
  1024×65536 149 → ~770 GB/s — now matching tall/square arrays.
- Reductions: **~25–31% faster** for small/medium sizes (the two eliminated memset
  launches), e.g. reused reducer N=1000 44.5 → 30.8 µs. Large bandwidth-bound
  reductions unchanged.
- Tall/square `parallel_for` unchanged (within noise).

## Correctness / tests

Behavior is unchanged for the supported contract (identity `init`). Validated on A100
(CUDA) and CPU threads — `reduce` 15, `reduce-ND` 20, `LaunchSpec` 14,
`parallel_for non-square` 16, `parallel_reduce non-square` 8, all pass. Adds
non-square 2D regression tests to `test/unittests.jl`; the existing 2D tests only
used square matrices, so they never exercised the axis-swap path:

```julia
@testset "parallel_for non-square 2D" begin
    write2d(i, j, A) = (@inbounds A[i, j] = (j - 1) * size(A, 1) + i; nothing)
    for (M, N) in [(2, 5), (5, 2), (7, 13), (128, 1024), (1024, 128), (3, 257)]
        A = JACC.zeros(FloatType, M, N)
        JACC.parallel_for((M, N), write2d, A)
        @test JACC.to_host(A) == FloatType[(j - 1) * M + i for i in 1:M, j in 1:N]
    end
end
```

## Notes
- Out of scope: `parallel_reduce` on 2D still has no swap path (hard-coded 16×16),
  so it overflows the y-grid for `N > ~1.05M` — a separate follow-up.