### PR TITLE
Add an opt-in Metal array storage preference

### DIFF
--- a/docs/src/api_usage.md
+++ b/docs/src/api_usage.md
@@ -54,7 +54,7 @@ JACC.@init_backend
 
 ## Memory allocation
 
-- **`JACC.array()`**: create a new array on the device with the specified type and size, or copy a host array to the device. On the Metal backend, `JACC.array(x; storage = :shared)` copies into unified (`SharedStorage`) memory visible to both CPU and GPU instead of the default device-private storage.
+- **`JACC.array()`**: create a new array on the device with the specified type and size, or copy a host array to the device. Metal projects can opt into unified (`SharedStorage`) memory for host-array copies with `JACC.set_backend("Metal"; storage = :shared)`; portable code continues to call `JACC.array(x)` without backend-specific keywords. The default is `:private`. Shared storage removes the construction copy, but its GPU-bandwidth cost for compute-bound workloads is unmeasured here.
 - **`JACC.zeros`**: create a new array on the device filled with zeros.
 - **`JACC.ones`**: create a new array on the device filled with ones.
 - **`JACC.fill`**: create a new array on the device filled with a specified value.

--- a/docs/src/api_usage.md
+++ b/docs/src/api_usage.md
@@ -54,7 +54,7 @@ JACC.@init_backend
 
 ## Memory allocation
 
-- **`JACC.array()`**: create a new array on the device with the specified type and size.
+- **`JACC.array()`**: create a new array on the device with the specified type and size, or copy a host array to the device. On the Metal backend, `JACC.array(x; storage = :shared)` copies into unified (`SharedStorage`) memory visible to both CPU and GPU instead of the default device-private storage.
 - **`JACC.zeros`**: create a new array on the device filled with zeros.
 - **`JACC.ones`**: create a new array on the device filled with ones.
 - **`JACC.fill`**: create a new array on the device filled with a specified value.

--- a/docs/src/api_usage.md
+++ b/docs/src/api_usage.md
@@ -10,7 +10,7 @@ JACC APIs consist of three main components:
 
 ## Backend selection
 
-- **`JACC.set_backend`**: allows selecting the runtime backend on **CPU**: `Threads` (default) and **GPU**: `CUDA`, `AMDGPU`, `oneAPI`. Uses Preferences.jl and stores the selected backend in a [LocalPreferences.jl](https://github.com/JuliaPackaging/Preferences.jl) file if JACC.jl is a project dependency. Use `JACC.set_backend` prior to running any code targeting a particular backend.
+- **`JACC.set_backend`**: allows selecting the runtime backend on **CPU**: `Threads` (default) and **GPU**: `CUDA`, `AMDGPU`, `oneAPI`, `Metal`. Uses Preferences.jl and stores the selected backend in a [LocalPreferences.toml](https://github.com/JuliaPackaging/Preferences.jl) file if JACC.jl is a project dependency. Use `JACC.set_backend` prior to running any code targeting a particular backend.
 
 Example:
 ```julia
@@ -54,7 +54,7 @@ JACC.@init_backend
 
 ## Memory allocation
 
-- **`JACC.array()`**: create a new array on the device with the specified type and size, or copy a host array to the device. Metal projects can opt into unified (`SharedStorage`) memory for host-array copies with `JACC.set_backend("Metal"; storage = :shared)`; portable code continues to call `JACC.array(x)` without backend-specific keywords. The default is `:private`. Shared storage removes the construction copy, but its GPU-bandwidth cost for compute-bound workloads is unmeasured here.
+- **`JACC.array()`**: create a new array on the device with the specified type and size, or copy a host array to the device. Metal projects can opt into unified (`SharedStorage`) memory for host-array copies with `JACC.set_backend("Metal"; storage = :shared)`; portable code continues to call `JACC.array(x)` without backend-specific keywords. Host-array copies default to `:private`. Shared storage avoids the private-storage transfer path; its construction-latency and GPU-bandwidth tradeoffs should be measured for the target workload.
 - **`JACC.zeros`**: create a new array on the device filled with zeros.
 - **`JACC.ones`**: create a new array on the device filled with ones.
 - **`JACC.fill`**: create a new array on the device filled with a specified value.

--- a/ext/MetalExt/MetalExt.jl
+++ b/ext/MetalExt/MetalExt.jl
@@ -411,4 +411,17 @@ JACC.array_type(::MetalBackend) = Metal.MtlArray
 
 JACC.array(::MetalBackend, x::Base.Array) = Metal.MtlArray(x)
 
+function _storage_mode(storage::Symbol)
+    storage === :shared && return Metal.SharedStorage
+    storage === :private && return Metal.PrivateStorage
+    throw(ArgumentError(string("unknown storage mode ", repr(storage),
+        " for the Metal backend; supported values are :shared and :private")))
+end
+
+function JACC._array_storage(
+        ::MetalBackend, x::AbstractArray, storage::Symbol)
+    S = _storage_mode(storage)
+    return Metal.MtlArray{eltype(x), ndims(x), S}(x)
+end
+
 end # module MetalExt

--- a/ext/MetalExt/MetalExt.jl
+++ b/ext/MetalExt/MetalExt.jl
@@ -409,7 +409,7 @@ JACC.sync_workgroup(::MetalBackend) = Metal.threadgroup_barrier()
 
 JACC.array_type(::MetalBackend) = Metal.MtlArray
 
-function _array_storage()
+function _compute_array_storage()
     preferences = get(
         JACC.Preferences.Backend._EXT_PREFS[], "metal", Dict{Symbol, Any}())
     value = get(preferences, :storage, "private")
@@ -421,6 +421,26 @@ function _array_storage()
         "Invalid Metal array storage: $(repr(value)); " *
         "expected :private or :shared"))
     return storage
+end
+
+# Cached module global rather than a plain module-load-once value: `storage`
+# is one of the extension preferences `set_backend` is documented (and
+# tested, see array_storage_preference in test/backend/metal.jl) to apply
+# live within the same Julia session, without a restart. _EXT_PREFS_GENERATION
+# is bumped on every write, so this stays a cheap Int comparison on the
+# array-allocation hot path instead of a Dict lookup plus revalidation on
+# every call, while still tracking live changes.
+const _ARRAY_STORAGE_CACHE = Ref{Tuple{Int, String}}((-1, ""))
+
+function _array_storage()
+    generation = JACC.Preferences.Backend._EXT_PREFS_GENERATION[]
+    cached_generation, cached_value = _ARRAY_STORAGE_CACHE[]
+    if cached_generation == generation
+        return cached_value
+    end
+    value = _compute_array_storage()
+    _ARRAY_STORAGE_CACHE[] = (generation, value)
+    return value
 end
 
 function JACC._array(::MetalBackend, x::AbstractArray)

--- a/ext/MetalExt/MetalExt.jl
+++ b/ext/MetalExt/MetalExt.jl
@@ -409,8 +409,18 @@ JACC.sync_workgroup(::MetalBackend) = Metal.threadgroup_barrier()
 
 JACC.array_type(::MetalBackend) = Metal.MtlArray
 
+function _array_storage()
+    preferences = get(
+        JACC.Preferences.Backend._EXT_PREFS[], "metal", Dict{Symbol, Any}())
+    storage = lowercase(String(get(preferences, :storage, "private")))
+    storage in ("private", "shared") || throw(ArgumentError(
+        "Invalid Metal array storage: $(repr(storage)); " *
+        "expected :private or :shared"))
+    return storage
+end
+
 function JACC._array(::MetalBackend, x::AbstractArray)
-    if JACC.Preferences.Metal._ARRAY_STORAGE[] == "shared"
+    if _array_storage() == "shared"
         return Metal.MtlArray{eltype(x), ndims(x), Metal.SharedStorage}(x)
     end
     return Metal.MtlArray(x)

--- a/ext/MetalExt/MetalExt.jl
+++ b/ext/MetalExt/MetalExt.jl
@@ -412,9 +412,13 @@ JACC.array_type(::MetalBackend) = Metal.MtlArray
 function _array_storage()
     preferences = get(
         JACC.Preferences.Backend._EXT_PREFS[], "metal", Dict{Symbol, Any}())
-    storage = lowercase(String(get(preferences, :storage, "private")))
+    value = get(preferences, :storage, "private")
+    value isa Union{AbstractString, Symbol} || throw(ArgumentError(
+        "Invalid Metal array storage: $(repr(value)); " *
+        "expected :private or :shared"))
+    storage = lowercase(String(value))
     storage in ("private", "shared") || throw(ArgumentError(
-        "Invalid Metal array storage: $(repr(storage)); " *
+        "Invalid Metal array storage: $(repr(value)); " *
         "expected :private or :shared"))
     return storage
 end
@@ -423,7 +427,11 @@ function JACC._array(::MetalBackend, x::AbstractArray)
     if _array_storage() == "shared"
         return Metal.MtlArray{eltype(x), ndims(x), Metal.SharedStorage}(x)
     end
-    return Metal.MtlArray(x)
+    return Metal.MtlArray{eltype(x), ndims(x), Metal.PrivateStorage}(x)
 end
+
+JACC._array(::MetalBackend, x::Metal.MtlArray) = x
+JACC.array(backend::MetalBackend, x::Base.Array) = JACC._array(backend, x)
+JACC.array(::MetalBackend, x::Metal.MtlArray) = x
 
 end # module MetalExt

--- a/ext/MetalExt/MetalExt.jl
+++ b/ext/MetalExt/MetalExt.jl
@@ -409,19 +409,11 @@ JACC.sync_workgroup(::MetalBackend) = Metal.threadgroup_barrier()
 
 JACC.array_type(::MetalBackend) = Metal.MtlArray
 
-JACC.array(::MetalBackend, x::Base.Array) = Metal.MtlArray(x)
-
-function _storage_mode(storage::Symbol)
-    storage === :shared && return Metal.SharedStorage
-    storage === :private && return Metal.PrivateStorage
-    throw(ArgumentError(string("unknown storage mode ", repr(storage),
-        " for the Metal backend; supported values are :shared and :private")))
-end
-
-function JACC._array_storage(
-        ::MetalBackend, x::AbstractArray, storage::Symbol)
-    S = _storage_mode(storage)
-    return Metal.MtlArray{eltype(x), ndims(x), S}(x)
+function JACC._array(::MetalBackend, x::AbstractArray)
+    if JACC.Preferences.Metal._ARRAY_STORAGE[] == "shared"
+        return Metal.MtlArray{eltype(x), ndims(x), Metal.SharedStorage}(x)
+    end
+    return Metal.MtlArray(x)
 end
 
 end # module MetalExt

--- a/src/array.jl
+++ b/src/array.jl
@@ -78,7 +78,7 @@ or copy the host array `x` to the device.
 
 Backend-specific allocation policy is configured outside portable code. For
 example, `set_backend("Metal"; storage = :shared)` makes host-array copies use
-Metal unified memory for that project. The default remains device-private.
+Metal unified memory for that project. Host-array copies default to device-private.
 """
 array(x::AbstractArray) = _array(default_backend(), x)
 _array(::Any, x::AbstractArray) = to_device(x)

--- a/src/array.jl
+++ b/src/array.jl
@@ -71,10 +71,29 @@ end
 
 """
     array([T=default_float()], dims...)
+    array(x::AbstractArray; storage = nothing)
 
-Create an uninitialized array on the device with the specified type and size.
+Create an uninitialized array on the device with the specified type and size,
+or copy the host array `x` to the device.
+
+The `storage` keyword (copy form only) requests a backend-specific storage
+mode. With the default `storage = nothing` the behavior is identical to
+[`to_device`](@ref). Currently only the Metal backend supports it:
+`:shared` copies into unified memory visible to both CPU and GPU, and
+`:private` copies into device-private storage (the Metal default). Any
+other backend throws an `ArgumentError` for a value other than `nothing`.
 """
-array(x::AbstractArray) = to_device(x)
+function array(x::AbstractArray; storage = nothing)
+    storage === nothing && return to_device(x)
+    return _array_storage(default_backend(), x, storage)
+end
+
+function _array_storage(bknd, x::AbstractArray, storage)
+    throw(ArgumentError(string("storage mode ", repr(storage),
+        " is not supported by the ", nameof(typeof(bknd)),
+        "; the `storage` keyword of `JACC.array` currently requires the Metal backend")))
+end
+
 array(::Type{T}, dims) where {T} = array_type(){T, length(dims)}(undef, dims)
 array(::Type{T}, dims...) where {T} = array(T, dims)
 array(dims) = array(default_float(), dims)

--- a/src/array.jl
+++ b/src/array.jl
@@ -71,28 +71,17 @@ end
 
 """
     array([T=default_float()], dims...)
-    array(x::AbstractArray; storage = nothing)
+    array(x::AbstractArray)
 
 Create an uninitialized array on the device with the specified type and size,
 or copy the host array `x` to the device.
 
-The `storage` keyword (copy form only) requests a backend-specific storage
-mode. With the default `storage = nothing` the behavior is identical to
-[`to_device`](@ref). Currently only the Metal backend supports it:
-`:shared` copies into unified memory visible to both CPU and GPU, and
-`:private` copies into device-private storage (the Metal default). Any
-other backend throws an `ArgumentError` for a value other than `nothing`.
+Backend-specific allocation policy is configured outside portable code. For
+example, `set_backend("Metal"; storage = :shared)` makes host-array copies use
+Metal unified memory for that project. The default remains device-private.
 """
-function array(x::AbstractArray; storage = nothing)
-    storage === nothing && return to_device(x)
-    return _array_storage(default_backend(), x, storage)
-end
-
-function _array_storage(bknd, x::AbstractArray, storage)
-    throw(ArgumentError(string("storage mode ", repr(storage),
-        " is not supported by the ", nameof(typeof(bknd)),
-        "; the `storage` keyword of `JACC.array` currently requires the Metal backend")))
-end
+array(x::AbstractArray) = _array(default_backend(), x)
+_array(::Any, x::AbstractArray) = to_device(x)
 
 array(::Type{T}, dims) where {T} = array_type(){T, length(dims)}(undef, dims)
 array(::Type{T}, dims...) where {T} = array(T, dims)

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -91,6 +91,29 @@ const _DEFAULT = Ref(String(default))
 const list = @load_preference("backends", ["threads"])
 const _LIST = Ref(deepcopy(list))
 const _PLACE = Ref(@load_preference("placement", Dict{String, String}()))
+const extension_preferences = @load_preference(
+    "extension_preferences", Dict{String, Any}())
+
+_serialize_extension_preference(value::Symbol) = String(value)
+function _serialize_extension_preference(value::AbstractDict)
+    return Dict(
+        String(key) => _serialize_extension_preference(item)
+        for (key, item) in value)
+end
+function _serialize_extension_preference(value::Union{Tuple, AbstractVector})
+    return [_serialize_extension_preference(item) for item in value]
+end
+_serialize_extension_preference(value) = value
+
+function _runtime_extension_preferences(preferences)
+    return Dict{String, Dict{Symbol, Any}}(
+        String(backend) => Dict{Symbol, Any}(
+            Symbol(key) => value
+            for (key, value) in values)
+        for (backend, values) in preferences)
+end
+
+const _EXT_PREFS = Ref(_runtime_extension_preferences(extension_preferences))
 
 const package_names = ["CUDA", "AMDGPU", "oneAPI", "Metal"]
 
@@ -119,15 +142,6 @@ end
 const imports = Expr(:block, _backend_import.(list)...)
 
 end
-
-module Metal
-
-import Base: String
-import Preferences: @load_preference
-const array_storage = @load_preference("metal_array_storage", "private")
-const _ARRAY_STORAGE = Ref(String(array_storage))
-
-end
 end
 
 const backend = Preferences.Backend.default
@@ -149,8 +163,8 @@ function unset_backend()
     @delete_preferences!("default_backend")
     @delete_preferences!("backends")
     @delete_preferences!("placement")
-    @delete_preferences!("metal_array_storage")
-    Preferences.Metal._ARRAY_STORAGE[] = "private"
+    @delete_preferences!("extension_preferences")
+    empty!(Preferences.Backend._EXT_PREFS[])
     @info """
         Backend preferences deleted
         Restart your Julia session for this change to take effect!
@@ -182,27 +196,25 @@ function set_default_backend(new_backend::Symbol)
     set_default_backend(String(new_backend))
 end
 
-function _set_metal_array_storage(storage::Union{AbstractString, Symbol})
-    value = lowercase(String(storage))
-    value in ("private", "shared") || throw(ArgumentError(
-        "Invalid Metal array storage: $(repr(storage)); expected :private or :shared"))
-    Preferences.Metal._ARRAY_STORAGE[] = value
-    @set_preferences!("metal_array_storage"=>value)
-    @info "Metal array storage set to :$(value)"
+function _set_extension_preferences(backend::String, kw)
+    values = Dict{Symbol, Any}(pairs((; kw...)))
+    isempty(values) && return
+
+    preferences = deepcopy(Preferences.Backend._EXT_PREFS[])
+    preferences[backend] = values
+    serialize = Preferences.Backend._serialize_extension_preference
+    persisted = Dict(
+        name => serialize(settings)
+        for (name, settings) in preferences)
+    @set_preferences!("extension_preferences"=>persisted)
+    Preferences.Backend._EXT_PREFS[] = preferences
 end
 
-function set_backend(b::AbstractString; storage = nothing)
+function set_backend(b::AbstractString; kw...)
     nb = lowercase(b)
-    if storage !== nothing
-        nb == "metal" || throw(ArgumentError(
-            "the storage preference is only valid for the Metal backend"))
-        value = lowercase(String(storage))
-        value in ("private", "shared") || throw(ArgumentError(
-            "Invalid Metal array storage: $(repr(storage)); expected :private or :shared"))
-    end
     if Preferences.Backend._LIST[] == [nb]
         if Preferences.Backend._DEFAULT[] == nb
-            storage === nothing || _set_metal_array_storage(storage)
+            _set_extension_preferences(nb, kw)
             return
         end
     else
@@ -210,7 +222,7 @@ function set_backend(b::AbstractString; storage = nothing)
         unset_backend()
     end
     set_default_backend(nb)
-    storage === nothing || _set_metal_array_storage(storage)
+    _set_extension_preferences(nb, kw)
 end
 
 set_backend(b::Symbol; kw...) = set_backend(String(b); kw...)

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -119,6 +119,15 @@ end
 const imports = Expr(:block, _backend_import.(list)...)
 
 end
+
+module Metal
+
+import Base: String
+import Preferences: @load_preference
+const array_storage = @load_preference("metal_array_storage", "private")
+const _ARRAY_STORAGE = Ref(String(array_storage))
+
+end
 end
 
 const backend = Preferences.Backend.default
@@ -140,6 +149,8 @@ function unset_backend()
     @delete_preferences!("default_backend")
     @delete_preferences!("backends")
     @delete_preferences!("placement")
+    @delete_preferences!("metal_array_storage")
+    Preferences.Metal._ARRAY_STORAGE[] = "private"
     @info """
         Backend preferences deleted
         Restart your Julia session for this change to take effect!
@@ -171,10 +182,27 @@ function set_default_backend(new_backend::Symbol)
     set_default_backend(String(new_backend))
 end
 
-function set_backend(b::AbstractString)
+function _set_metal_array_storage(storage::Union{AbstractString, Symbol})
+    value = lowercase(String(storage))
+    value in ("private", "shared") || throw(ArgumentError(
+        "Invalid Metal array storage: $(repr(storage)); expected :private or :shared"))
+    Preferences.Metal._ARRAY_STORAGE[] = value
+    @set_preferences!("metal_array_storage"=>value)
+    @info "Metal array storage set to :$(value)"
+end
+
+function set_backend(b::AbstractString; storage = nothing)
     nb = lowercase(b)
+    if storage !== nothing
+        nb == "metal" || throw(ArgumentError(
+            "the storage preference is only valid for the Metal backend"))
+        value = lowercase(String(storage))
+        value in ("private", "shared") || throw(ArgumentError(
+            "Invalid Metal array storage: $(repr(storage)); expected :private or :shared"))
+    end
     if Preferences.Backend._LIST[] == [nb]
         if Preferences.Backend._DEFAULT[] == nb
+            storage === nothing || _set_metal_array_storage(storage)
             return
         end
     else
@@ -182,9 +210,10 @@ function set_backend(b::AbstractString)
         unset_backend()
     end
     set_default_backend(nb)
+    storage === nothing || _set_metal_array_storage(storage)
 end
 
-set_backend(b::Symbol) = set_backend(String(b))
+set_backend(b::Symbol; kw...) = set_backend(String(b); kw...)
 
 function add_backend(new_backend::AbstractString)
     new_backend_lc = lowercase(new_backend)

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -114,6 +114,10 @@ function _runtime_extension_preferences(preferences)
 end
 
 const _EXT_PREFS = Ref(_runtime_extension_preferences(extension_preferences))
+# Bumped on every mutation of _EXT_PREFS so extensions can cheaply detect
+# staleness of any value they cache from it, without recomputing on every
+# call. See ext/MetalExt/MetalExt.jl `_array_storage` for the reader side.
+const _EXT_PREFS_GENERATION = Ref(0)
 
 const package_names = ["CUDA", "AMDGPU", "oneAPI", "Metal"]
 
@@ -165,6 +169,7 @@ function unset_backend()
     @delete_preferences!("placement")
     @delete_preferences!("extension_preferences")
     empty!(Preferences.Backend._EXT_PREFS[])
+    Preferences.Backend._EXT_PREFS_GENERATION[] += 1
     @info """
         Backend preferences deleted
         Restart your Julia session for this change to take effect!
@@ -208,6 +213,7 @@ function _set_extension_preferences(backend::String, kw)
         for (name, settings) in preferences)
     @set_preferences!("extension_preferences"=>persisted)
     Preferences.Backend._EXT_PREFS[] = preferences
+    Preferences.Backend._EXT_PREFS_GENERATION[] += 1
 end
 
 function set_backend(b::AbstractString; kw...)

--- a/test/backend/metal.jl
+++ b/test/backend/metal.jl
@@ -21,23 +21,28 @@ end
     @test eltype(x) == Float32
 end
 
-@testset "array_storage" begin
+@testset "array_storage_preference" begin
     using Metal
+    using Suppressor
     N = 10
     h = ones(Float32, N)
     x = JACC.array(h)
     @test typeof(x) == MtlArray{Float32, 1, Metal.PrivateStorage}
-    xs = JACC.array(h; storage = :shared)
-    @test typeof(xs) == MtlArray{Float32, 1, Metal.SharedStorage}
-    @test Metal.is_shared(xs)
-    @test Array(xs) == h
-    xp = JACC.array(h; storage = :private)
-    @test typeof(xp) == MtlArray{Float32, 1, Metal.PrivateStorage}
-    @test Array(xp) == h
-    h2 = ones(Float32, N, N)
-    xs2 = JACC.array(h2; storage = :shared)
-    @test typeof(xs2) == MtlArray{Float32, 2, Metal.SharedStorage}
-    @test_throws ArgumentError JACC.array(h; storage = :bogus)
+    try
+        @suppress JACC.set_backend("Metal"; storage = :shared)
+        @test load_preference(JACC, "metal_array_storage") == "shared"
+        xs = JACC.array(h)
+        @test typeof(xs) == MtlArray{Float32, 1, Metal.SharedStorage}
+        @test Metal.is_shared(xs)
+        @test Array(xs) == h
+        h2 = ones(Float32, N, N)
+        xs2 = JACC.array(h2)
+        @test typeof(xs2) == MtlArray{Float32, 2, Metal.SharedStorage}
+    finally
+        @suppress JACC.set_backend("Metal"; storage = :private)
+    end
+    @test_throws ArgumentError JACC.set_backend("Metal"; storage = :bogus)
+    @test_throws ArgumentError JACC.set_backend("CUDA"; storage = :shared)
 end
 
 include("preferences.jl")

--- a/test/backend/metal.jl
+++ b/test/backend/metal.jl
@@ -28,6 +28,10 @@ end
     h = ones(Float32, N)
     x = JACC.array(h)
     @test typeof(x) == MtlArray{Float32, 1, Metal.PrivateStorage}
+    @test JACC.array(x) === x
+    @test JACC.array(JACC.default_backend(), x) === x
+    @test JACC.array(JACC.default_backend(), h) isa
+          MtlArray{Float32, 1, Metal.PrivateStorage}
     try
         @suppress JACC.set_backend("Metal"; storage = :shared)
         preferences = load_preference(JACC, "extension_preferences")
@@ -38,13 +42,20 @@ end
         @test typeof(xs) == MtlArray{Float32, 1, Metal.SharedStorage}
         @test Metal.is_shared(xs)
         @test Array(xs) == h
+        @test JACC.array(xs) === xs
+        @test JACC.array(JACC.default_backend(), xs) === xs
+        @test JACC.array(JACC.default_backend(), h) isa
+              MtlArray{Float32, 1, Metal.SharedStorage}
         h2 = ones(Float32, N, N)
         xs2 = JACC.array(h2)
         @test typeof(xs2) == MtlArray{Float32, 2, Metal.SharedStorage}
     finally
         @suppress JACC.set_backend("Metal"; storage = :private)
     end
+    @test JACC.array(h) isa MtlArray{Float32, 1, Metal.PrivateStorage}
     @suppress JACC.set_backend("Metal"; storage = :bogus)
+    @test_throws ArgumentError JACC.array(h)
+    @suppress JACC.set_backend("Metal"; storage = 1)
     @test_throws ArgumentError JACC.array(h)
     @suppress JACC.set_backend("Metal"; storage = :private)
 end

--- a/test/backend/metal.jl
+++ b/test/backend/metal.jl
@@ -21,6 +21,25 @@ end
     @test eltype(x) == Float32
 end
 
+@testset "array_storage" begin
+    using Metal
+    N = 10
+    h = ones(Float32, N)
+    x = JACC.array(h)
+    @test typeof(x) == MtlArray{Float32, 1, Metal.PrivateStorage}
+    xs = JACC.array(h; storage = :shared)
+    @test typeof(xs) == MtlArray{Float32, 1, Metal.SharedStorage}
+    @test Metal.is_shared(xs)
+    @test Array(xs) == h
+    xp = JACC.array(h; storage = :private)
+    @test typeof(xp) == MtlArray{Float32, 1, Metal.PrivateStorage}
+    @test Array(xp) == h
+    h2 = ones(Float32, N, N)
+    xs2 = JACC.array(h2; storage = :shared)
+    @test typeof(xs2) == MtlArray{Float32, 2, Metal.SharedStorage}
+    @test_throws ArgumentError JACC.array(h; storage = :bogus)
+end
+
 include("preferences.jl")
 
 @testset "preferences" begin

--- a/test/backend/metal.jl
+++ b/test/backend/metal.jl
@@ -30,7 +30,10 @@ end
     @test typeof(x) == MtlArray{Float32, 1, Metal.PrivateStorage}
     try
         @suppress JACC.set_backend("Metal"; storage = :shared)
-        @test load_preference(JACC, "metal_array_storage") == "shared"
+        preferences = load_preference(JACC, "extension_preferences")
+        @test preferences["metal"]["storage"] == "shared"
+        @test JACC.Preferences.Backend._EXT_PREFS[]["metal"] ==
+              Dict(:storage => :shared)
         xs = JACC.array(h)
         @test typeof(xs) == MtlArray{Float32, 1, Metal.SharedStorage}
         @test Metal.is_shared(xs)
@@ -41,8 +44,9 @@ end
     finally
         @suppress JACC.set_backend("Metal"; storage = :private)
     end
-    @test_throws ArgumentError JACC.set_backend("Metal"; storage = :bogus)
-    @test_throws ArgumentError JACC.set_backend("CUDA"; storage = :shared)
+    @suppress JACC.set_backend("Metal"; storage = :bogus)
+    @test_throws ArgumentError JACC.array(h)
+    @suppress JACC.set_backend("Metal"; storage = :private)
 end
 
 include("preferences.jl")

--- a/test/backend/preferences.jl
+++ b/test/backend/preferences.jl
@@ -18,10 +18,11 @@ function test_preferences(bksym::Symbol)
         @test isempty(JACC.Preferences.Backend._PLACE[])
     end
 
-    if bkstr == "metal"
-        @suppress JACC.set_backend(bkstr; storage = :shared)
-        @test load_preference(JACC, "metal_array_storage") == "shared"
-    end
+    @suppress JACC.set_backend(bkstr; test_preference = true)
+    extension_preferences = load_preference(JACC, "extension_preferences")
+    @test extension_preferences[bkstr]["test_preference"]
+    @test JACC.Preferences.Backend._EXT_PREFS[][bkstr] ==
+          Dict(:test_preference => true)
 
     # Clear settings
     @suppress JACC.unset_backend()
@@ -29,8 +30,8 @@ function test_preferences(bksym::Symbol)
     @test isempty(JACC.Preferences.Backend._PLACE[])
     @test load_preference(JACC, "backends") == nothing
     @test load_preference(JACC, "default_backend") == nothing
-    @test load_preference(JACC, "metal_array_storage") == nothing
-    @test JACC.Preferences.Metal._ARRAY_STORAGE[] == "private"
+    @test load_preference(JACC, "extension_preferences") == nothing
+    @test isempty(JACC.Preferences.Backend._EXT_PREFS[])
 
     # "not a backend"
     @test_throws ArgumentError JACC.set_backend("NAB")

--- a/test/backend/preferences.jl
+++ b/test/backend/preferences.jl
@@ -18,12 +18,19 @@ function test_preferences(bksym::Symbol)
         @test isempty(JACC.Preferences.Backend._PLACE[])
     end
 
+    if bkstr == "metal"
+        @suppress JACC.set_backend(bkstr; storage = :shared)
+        @test load_preference(JACC, "metal_array_storage") == "shared"
+    end
+
     # Clear settings
     @suppress JACC.unset_backend()
     @test isempty(JACC.Preferences.Backend._LIST[])
     @test isempty(JACC.Preferences.Backend._PLACE[])
     @test load_preference(JACC, "backends") == nothing
     @test load_preference(JACC, "default_backend") == nothing
+    @test load_preference(JACC, "metal_array_storage") == nothing
+    @test JACC.Preferences.Metal._ARRAY_STORAGE[] == "private"
 
     # "not a backend"
     @test_throws ArgumentError JACC.set_backend("NAB")

--- a/test/backend/threads.jl
+++ b/test/backend/threads.jl
@@ -53,8 +53,7 @@ end
 end
 
 @testset "array_storage_unsupported" begin
-    @test_throws ArgumentError JACC.array(
-        ones(Float32, 10); storage = :shared)
+    @test_throws MethodError JACC.array(ones(Float32, 10); storage = :shared)
 end
 
 include("preferences.jl")

--- a/test/backend/threads.jl
+++ b/test/backend/threads.jl
@@ -52,6 +52,11 @@ end
     @test typeof(x) == Array{Complex{Float32}, 3}
 end
 
+@testset "array_storage_unsupported" begin
+    @test_throws ArgumentError JACC.array(
+        ones(Float32, 10); storage = :shared)
+end
+
 include("preferences.jl")
 
 @testset "preferences" begin

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -59,6 +59,12 @@ end
     @test ndims(x) == 3
     @test eltype(x) == Complex{Float32}
     @test size(x) == (5, 5, 5)
+
+    # copy from host; storage = nothing is the default path
+    h = ones(Float32, 10)
+    x = JACC.array(h)
+    @test typeof(JACC.array(h; storage = nothing)) == typeof(x)
+    @test JACC.to_host(x) == h
 end
 
 @testset "transfer!" begin

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -60,10 +60,9 @@ end
     @test eltype(x) == Complex{Float32}
     @test size(x) == (5, 5, 5)
 
-    # copy from host; storage = nothing is the default path
+    # Copy from host using the backend's configured storage policy.
     h = ones(Float32, 10)
     x = JACC.array(h)
-    @test typeof(JACC.array(h; storage = nothing)) == typeof(x)
     @test JACC.to_host(x) == h
 end
 


### PR DESCRIPTION
## Summary

- store backend-specific `set_backend(...; kw...)` options in a generic backend-keyed preference map
- let `MetalExt` consume and validate the `storage` option it owns
- keep the portable allocation call as `JACC.array(x)`
- preserve existing `MtlArray` identity for implicit and explicit Metal calls

With Metal's default settings, host-array copies use private storage. Projects can opt into shared storage with `JACC.set_backend("Metal"; storage = :shared)`.

## Motivation

This implements the storage-selection contribution discussed in #402 and the generic preference design requested in review.

Metal's `MtlArray(x)` construction path allocates and copies the source array (Metal.jl `array.jl:287-296`), with private storage selected by default (`array.jl:193-205`). On Apple Silicon, shared storage can avoid the private-storage transfer path.

## Measurement

On an Apple M4 with Julia 1.12.6 and Metal.jl 1.10.0, constructing 10,000,000 `Float32` elements produced these medians across 30 samples per path:

- private: 9,036.0 microseconds
- shared: 4,342.0 microseconds
- `:shared` was 52% lower than `:private`

Each construction was followed by `Metal.synchronize()`. Laptop idle state was uncontrolled. GPU bandwidth for compute-bound workloads remains unmeasured.

## Design

Core JACC persists backend options verbatim, and `MetalExt` owns `storage` interpretation and validation, so the portable `JACC.array(x)` signature stays backend-independent. Other preference lifecycle operations continue to use the existing Preferences.jl path.

The Metal specialization preserves the pre-PR identity behavior for existing `MtlArray` values and restores the explicit `JACC.array(backend, x)` host-copy method. `MetalExt`'s fully parameterized `MtlArray` constructors keep JACC's selected storage mode authoritative over Metal.jl's independent default.

## Verification

- `Pkg.test()`: 223 passed on Apple Silicon with Julia 1.12.6 and Metal.jl 1.10.0
- focused `array_storage_preference`: 16 passed
- coverage includes private and shared host copies, implicit and explicit identity, explicit host conversion, generic persisted state, and invalid Metal values
- `git diff --check`: passed

Reference: #402
