### PR TITLE
Add an opt-in AMDGPU array storage preference

### DIFF
--- a/ext/AMDGPUExt/AMDGPUExt.jl
+++ b/ext/AMDGPUExt/AMDGPUExt.jl
@@ -597,6 +597,47 @@ JACC.sync_workgroup(::AMDGPUBackend) = AMDGPU.sync_workgroup()
 
 JACC.array_type(::AMDGPUBackend) = AMDGPU.ROCArray
 
-JACC.array(::AMDGPUBackend, x::AbstractArray) = AMDGPU.ROCArray(x)
+function _compute_array_storage()
+    preferences = get(
+        JACC.Preferences.Backend._EXT_PREFS[], "amdgpu", Dict{Symbol, Any}())
+    value = get(preferences, :storage, "device")
+    value isa Union{AbstractString, Symbol} || throw(ArgumentError(
+        "Invalid AMDGPU array storage: $(repr(value)); " *
+        "expected :device or :host"))
+    storage = lowercase(String(value))
+    storage in ("device", "host") || throw(ArgumentError(
+        "Invalid AMDGPU array storage: $(repr(value)); " *
+        "expected :device or :host"))
+    return storage
+end
+
+# Same live-preference cache as ext/MetalExt/MetalExt.jl `_array_storage`:
+# _EXT_PREFS_GENERATION is bumped on every set_backend write, so this is a
+# cheap Int comparison on the allocation hot path.
+const _ARRAY_STORAGE_CACHE = Ref{Tuple{Int, String}}((-1, ""))
+
+function _array_storage()
+    generation = JACC.Preferences.Backend._EXT_PREFS_GENERATION[]
+    cached_generation, cached_value = _ARRAY_STORAGE_CACHE[]
+    if cached_generation == generation
+        return cached_value
+    end
+    value = _compute_array_storage()
+    _ARRAY_STORAGE_CACHE[] = (generation, value)
+    return value
+end
+
+function JACC._array(::AMDGPUBackend, x::AbstractArray)
+    if _array_storage() == "host"
+        # hipHostMalloc-backed pinned memory: zero-copy CPU+GPU access on
+        # APUs, fast DMA on discrete GPUs.
+        return AMDGPU.ROCArray{eltype(x), ndims(x), AMDGPU.Mem.HostBuffer}(x)
+    end
+    return AMDGPU.ROCArray{eltype(x), ndims(x), AMDGPU.Mem.HIPBuffer}(x)
+end
+
+JACC._array(::AMDGPUBackend, x::AMDGPU.ROCArray) = x
+JACC.array(backend::AMDGPUBackend, x::AbstractArray) = JACC._array(backend, x)
+JACC.array(::AMDGPUBackend, x::AMDGPU.ROCArray) = x
 
 end # module AMDGPUExt

--- a/test/backend/amdgpu.jl
+++ b/test/backend/amdgpu.jl
@@ -57,6 +57,48 @@ end
     @test typeof(x) == ROCArray{Complex{Float32}, 3, HIPBuffer}
 end
 
+@testset "array_storage_preference" begin
+    using AMDGPU
+    import AMDGPU.Runtime.Mem: HIPBuffer, HostBuffer
+    using Suppressor
+    N = 10
+    h = ones(Float32, N)
+    x = JACC.array(h)
+    @test typeof(x) == ROCVector{Float32, HIPBuffer}
+    @test JACC.array(x) === x
+    @test JACC.array(JACC.default_backend(), x) === x
+    @test JACC.array(JACC.default_backend(), h) isa
+          ROCVector{Float32, HIPBuffer}
+    try
+        @suppress JACC.set_backend("AMDGPU"; storage = :host)
+        preferences = load_preference(JACC, "extension_preferences")
+        @test preferences["amdgpu"]["storage"] == "host"
+        @test JACC.Preferences.Backend._EXT_PREFS[]["amdgpu"] ==
+              Dict(:storage => :host)
+        xs = JACC.array(h)
+        @test typeof(xs) == ROCVector{Float32, HostBuffer}
+        @test Array(xs) == h
+        @test JACC.array(xs) === xs
+        @test JACC.array(JACC.default_backend(), xs) === xs
+        @test JACC.array(JACC.default_backend(), h) isa
+              ROCVector{Float32, HostBuffer}
+        h2 = ones(Float32, N, N)
+        xs2 = JACC.array(h2)
+        @test typeof(xs2) == ROCMatrix{Float32, HostBuffer}
+        # host-pinned arrays must be usable from kernels (zero-copy path)
+        JACC.parallel_for(N, (i, a) -> (a[i] += 1f0), xs)
+        @test Array(xs) == h .+ 1f0
+    finally
+        @suppress JACC.set_backend("AMDGPU"; storage = :device)
+    end
+    @test JACC.array(h) isa ROCVector{Float32, HIPBuffer}
+    @suppress JACC.set_backend("AMDGPU"; storage = :bogus)
+    @test_throws ArgumentError JACC.array(h)
+    @suppress JACC.set_backend("AMDGPU"; storage = 1)
+    @test_throws ArgumentError JACC.array(h)
+    @suppress JACC.set_backend("AMDGPU"; storage = :device)
+end
+
 @testset "stream" begin
     using AMDGPU
     sd1 = JACC.default_stream()


### PR DESCRIPTION
Follow-up to #405: the same opt-in storage preference, now for ROCm.

```julia
JACC.set_backend("AMDGPU"; storage = :host)
lattice = JACC.array(zeros(Int32, 240, 240, 240))  # ROCArray{Int32, 3, Mem.HostBuffer}
```

`:host` allocates through `hipHostMalloc`: pinned memory the GPU addresses directly via the buffer's device pointer. On an APU this is zero-copy — CPU and GPU read the same physical pages, so a host-side solver and a device kernel can share one allocation with no transfer between them. On a discrete card it is pinned staging memory at full DMA bandwidth. `:device`, the default, is the existing `HIPBuffer` path, unchanged.

The extension side mirrors `MetalExt` line for line: the preference is validated on read and cached behind `_EXT_PREFS_GENERATION`, so a live `set_backend` call takes effect without a restart while the allocation hot path stays a single `Int` comparison.

Two modes only. HIP's managed memory has no `ROCArray` buffer type to carry it, so this PR promises no `:coherent` — better to offer what the driver stack actually supports than to paper over it.

**Testing.** New `array_storage_preference` testset in `test/backend/amdgpu.jl`, structured like its Metal counterpart: allocation type and value-parity assertions under each mode, a `parallel_for` kernel writing through a `HostBuffer` array to prove the zero-copy path end to end, and `ArgumentError` checks for invalid values (`:bogus`, `1`) that run without hardware. Full suite passes locally on gfx1150 (Strix Point APU, ROCm, AMDGPU.jl 2.7.1); the testset rides the existing `ci-gpu-AMD.yaml` workflow with no CI changes.

Motivating case: a 3D Cellular Potts biofilm simulation whose Metropolis kernels run on the iGPU while a radiolysis PDE steps on the CPU — with `:host` storage the per-step field read-backs stop being copies at all.
