### PR TITLE
Fail loudly when a testset failure aborts the run before all testsets execute

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,9 +16,26 @@ if JACCBench.matches(ARGS)
         retest(JACCBench, filter; spin = false)
     end
 else
-    if isempty(ARGS)
-        retest(JACCTests)
-    else
-        retest(JACCTests, ARGS)
+    try
+        if isempty(ARGS)
+            retest(JACCTests)
+        else
+            retest(JACCTests, ARGS)
+        end
+    catch
+        # retest() throws as soon as a testset fails, so every testset
+        # defined after the failing one silently never runs — a failure in
+        # the backend testsets (defined first) skips the entire compute
+        # suite, and the partial results table reads as a mostly-green run
+        # (issue #403). Make the abort say what it skipped.
+        println()
+        printstyled(
+            "ERROR: the test run ABORTED at the first failing testset.\n";
+            color = :red, bold = true)
+        println(
+            "Any testset absent from the results table above NEVER RAN.\n",
+            "The full list of testsets this run was supposed to execute is:")
+        retest(JACCTests; dry = true)
+        rethrow()
     end
 end


### PR DESCRIPTION
Closes #403.

`retest()` throws at the first failing testset, and everything defined after it silently never runs. The backend testsets are defined before `unittests.jl`, so a single backend failure — a preferences mismatch, a stream assertion — skips all 25+ compute testsets, and the log ends with a partial table that reads as a mostly-green run:

```
Main.JACCTests    |     71       2      73
ERROR: Package JACC errored during testing
```

Zero compute tests executed there. Nothing in the output says so.

This is the minimal remedy from #403's three options: keep the harness structure exactly as it is, but make the abort tell the truth. The `retest(JACCTests, ...)` call is wrapped in a try/catch that, on failure, prints a red banner — the run **aborted** at the first failing testset, and any testset absent from the table above never ran — followed by `retest(JACCTests; dry = true)`, ReTest's own listing of every testset the run was supposed to execute. Then it rethrows, so exit status and `Pkg.test` behavior are unchanged.

Verified on gfx1150: with an injected failing backend testset, the abort now ends with the banner and the full 27-entry listing (`reduce-ND`, `CG`, `LBM`, `rand-Float64`, … — the compute suite a reader would otherwise assume had passed); on a clean run the guard prints nothing and the suite passes as before.

Deferring the backend testsets into `retest()` proper, or running compute regardless of backend failures, would be the deeper fix — but both change test-selection semantics, and that choice belongs to the maintainers. This PR only removes the false green.


