### PR TITLE
test: make the Multi backend exclusions visible, and run them on AMDGPU

### DIFF
--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1056,7 +1056,7 @@ end
     @test f2≈JACC.to_host(df2) rtol=1e-1
 end
 
-if JACC.backend != "amdgpu" && JACC.backend != "metal"
+if JACC.backend != "metal"
     @testset "Multi" begin
         # Unidimensional arrays
         SIZE = 10
@@ -1168,7 +1168,7 @@ else
     end
 end
 
-if JACC.backend != "amdgpu" && JACC.backend != "metal"
+if JACC.backend != "metal"
     @testset "CG Async" begin
         function matvecmul(i, a1, a2, a3, x, y, SIZE)
             if i == 1

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1160,6 +1160,12 @@ if JACC.backend != "amdgpu" && JACC.backend != "metal"
         end
         @test cond <= 1e-14
     end
+else
+    # A source-level exclusion leaves no trace in the report, so a green run on
+    # these backends reads as Multi coverage it does not have (JACC.jl#381).
+    @testset "Multi (not run on $(JACC.backend), see JACC.jl#381)" begin
+        @test_skip "JACC.Multi on $(JACC.backend)"
+    end
 end
 
 if JACC.backend != "amdgpu" && JACC.backend != "metal"
@@ -1222,6 +1228,10 @@ if JACC.backend != "amdgpu" && JACC.backend != "metal"
             copyto!(p, r_aux)
         end
         @test cond[1, 1] <= 1e-14
+    end
+else
+    @testset "CG Async (not run on $(JACC.backend), see JACC.jl#381)" begin
+        @test_skip "JACC.Multi async CG on $(JACC.backend)"
     end
 end
 


### PR DESCRIPTION
Follow-up to #381, where @williamfgc asked for the AMD `Multi` path to be re-tested.

### The reporting problem

`Multi` and `CG Async` were excluded at the source level:

```julia
if JACC.backend != "amdgpu" && JACC.backend != "metal"
    @testset "Multi" begin
```

On those backends the testsets are never registered, so they leave no trace in the
report at all — no skip, no count, no reason. A green AMDGPU run therefore carries no
`Multi` information, and the only way to know is to read the source. The first commit
registers them instead as skipped testsets naming the backend and the issue:

```
Multi (not run on metal, see JACC.jl#381)    |    Broken 1
```

The reason lives in the testset name deliberately: under ReTest at default verbosity the
summary prints only top-level testset names, so a nested testset or a `@test_skip`
argument string is invisible in a pasted report (and `@test_skip` never evaluates its
argument, so interpolation there is dead). `@test_skip` supplies the machine-visible
Broken count. `Pkg.test(test_args=["Multi"])` still matches the renamed testsets.

### Running the AMD path

The second commit drops `"amdgpu"` from both gates. Both testsets pass on a consumer
iGPU — gfx1150 (Radeon 890M, Strix Point), Ubuntu 26.04 archive ROCm 7.1, AMDGPU.jl
2.7.1, Julia 1.12.6, Float64 (backend default), `ndev = 1`: **Multi 5/5, CG Async 1/1**.
Exercised `Multi.array`, `Multi.parallel_for`, `Multi.parallel_reduce` (1-D and 2-D
axpy/dot), an HPCG-style ghost-shift matvec, and async CG. Metal keeps the visible skip.

**This is single-device and cannot exercise the cross-device communication issue** that
motivated the original exclusion — the 4×MI300A run is the one that decides it. One
observation that may matter there: the AMD run emits `Resource leak detected by
SharedSignalPool, 19 Signals leaked`. Harmless at `ndev = 1`, possibly not at 4.

If it fails on real multi-GPU hardware, revert the second commit — the first stays useful,
and the skip then carries the real reason instead of nothing.

### Verification

- amdgpu: `Multi 5/5`, `CG Async 1/1`
- threads (regression, the else branch must not steal the passing path): `Multi 5/5`, `CG Async 1/1`, Broken 0
- metal/other excluded backends: both testsets appear with Broken 1 and the reason in the name

Touches `test/unittests.jl` only. Five sibling exclusions (`shared`/oneAPI, 7-D
`parallel_for`/Metal, `StepRange`/Metal, `rand-Float32`/`rand-Float64`/oneAPI) have the
same invisible shape; sweeping them wants a small `@testset_or_skip` macro rather than six
copied `else` blocks — happy to do that here or separately if you want it.
