### PR TITLE
ci: upload GPU coverage to the tested PR commit, not to main's head

### DIFF
--- a/.github/workflows/ci-gpu-AMD.yaml
+++ b/.github/workflows/ci-gpu-AMD.yaml
@@ -101,8 +101,9 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: true
-          base_sha: ${{fromJson(steps.request.outputs.data).head.sha}}
-          override_pr: ${{ github.event.pull_request.number }}
+          override_commit: ${{fromJson(steps.request.outputs.data).head.sha}}
+          override_branch: ${{steps.pr_data.outputs.branch}}
+          override_pr: ${{github.event.issue.number}}
           flags: amdgpu
 
       - name: Report PR status
@@ -211,8 +212,9 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: true
-          base_sha: ${{fromJson(steps.request.outputs.data).head.sha}}
-          override_pr: ${{ github.event.pull_request.number }}
+          override_commit: ${{fromJson(steps.request.outputs.data).head.sha}}
+          override_branch: ${{steps.pr_data.outputs.branch}}
+          override_pr: ${{github.event.issue.number}}
           flags: amdgpu
 
       - name: Report PR status

--- a/.github/workflows/ci-gpu-Apple.yaml
+++ b/.github/workflows/ci-gpu-Apple.yaml
@@ -95,8 +95,9 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: true
-          base_sha: ${{fromJson(steps.request.outputs.data).head.sha}}
-          override_pr: ${{ github.event.pull_request.number }}
+          override_commit: ${{fromJson(steps.request.outputs.data).head.sha}}
+          override_branch: ${{steps.pr_data.outputs.branch}}
+          override_pr: ${{github.event.issue.number}}
           flags: metal
 
       - name: Report PR status

--- a/.github/workflows/ci-gpu-Intel.yaml
+++ b/.github/workflows/ci-gpu-Intel.yaml
@@ -105,8 +105,9 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: true
-          base_sha: ${{fromJson(steps.request.outputs.data).head.sha}}
-          override_pr: ${{ github.event.pull_request.number }}
+          override_commit: ${{fromJson(steps.request.outputs.data).head.sha}}
+          override_branch: ${{steps.pr_data.outputs.branch}}
+          override_pr: ${{github.event.issue.number}}
           flags: oneapi
 
       - name: Report PR status

--- a/.github/workflows/ci-gpu-NVIDIA.yaml
+++ b/.github/workflows/ci-gpu-NVIDIA.yaml
@@ -94,8 +94,9 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: true
-          base_sha: ${{fromJson(steps.request.outputs.data).head.sha}}
-          override_pr: ${{ github.event.pull_request.number }}
+          override_commit: ${{fromJson(steps.request.outputs.data).head.sha}}
+          override_branch: ${{steps.pr_data.outputs.branch}}
+          override_pr: ${{github.event.issue.number}}
           flags: cuda
 
       - name: Report PR status
@@ -197,8 +198,9 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: true
-          base_sha: ${{fromJson(steps.request.outputs.data).head.sha}}
-          override_pr: ${{ github.event.pull_request.number }}
+          override_commit: ${{fromJson(steps.request.outputs.data).head.sha}}
+          override_branch: ${{steps.pr_data.outputs.branch}}
+          override_pr: ${{github.event.issue.number}}
           flags: cuda
 
       - name: Report PR status


### PR DESCRIPTION
Fixes #415, where the evidence lives.

The four comment-triggered GPU workflows passed the PR head SHA to codecov-action as
`base_sha`, an input consumed only by codecov's "pr-base-picking" run command, which
these workflows never invoke — so it was ignored outright. With no `override_commit` the action falls back to `GITHUB_SHA`, and
under `on: issue_comment` that's the default branch's head, so every GPU coverage upload
landed on `main` no matter which branch was checked out and tested.

`override_pr` had the same shape of problem: an `issue_comment` payload has no
`github.event.pull_request`, so the number was always empty.

```diff
-          base_sha: ${{fromJson(steps.request.outputs.data).head.sha}}
-          override_pr: ${{ github.event.pull_request.number }}
+          override_commit: ${{fromJson(steps.request.outputs.data).head.sha}}
+          override_branch: ${{steps.pr_data.outputs.branch}}
+          override_pr: ${{github.event.issue.number}}
```

Six upload steps across the four files, since AMD and NVIDIA have two jobs each. All three
values were already being computed in every job for the PR status steps, so nothing new is
fetched.

### Verification

The four files still parse, and the `Upload Coverage` step count per job is unchanged.
Beyond that I can't verify this from a fork: these workflows only run on the self-hosted
runners behind the actor allowlist, and a fork PR can't reach them.

Confirmation after merge is direct and cheap. The next "Test this please" should print an
upload URL naming that PR's head SHA rather than main's, the PR head's session count
should rise by the number of GPU jobs, and the next merge to `main` should land near 65%
instead of jumping. If it doesn't, #415 has the before-numbers to compare against.

