### PR TITLE
Add doc-cleanup workflow

### DIFF
--- a/.github/workflows/doc-cleanup.yaml
+++ b/.github/workflows/doc-cleanup.yaml
@@ -1,0 +1,33 @@
+name: Doc Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+# Ensure that only one "Doc Preview Cleanup" workflow is force pushing at a time
+concurrency:
+  group: doc-cleanup
+  cancel-in-progress: false
+
+jobs:
+  doc-cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+      - name: Delete preview and history + push changes
+        run: |
+          if [ -d "${preview_dir}" ]; then
+              git config user.name "Documenter.jl"
+              git config user.email "documenter@juliadocs.github.io"
+              git rm -rf "${preview_dir}"
+              git commit -m "delete preview"
+              git branch gh-pages-new "$(echo "delete history" | git commit-tree "HEAD^{tree}")"
+              git push --force origin gh-pages-new:gh-pages
+          fi
+        env:
+          preview_dir: previews/PR${{ github.event.number }}


### PR DESCRIPTION
Taken straight from [here](https://documenter.juliadocs.org/stable/man/hosting/#Cleaning-up-gh-pages) to keep the `gh-pages` branch history out of the way.